### PR TITLE
Add failed claims UI and status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ After installing dependencies and setting up the databases and model, run:
 python -m src.processing.main
 ```
 
+## Web UI
+Run the FastAPI server to view failed claims and monitor real-time sync status:
+
+```bash
+uvicorn src.web.app:app --reload
+```
+
+The `/failed_claims` page lists recent failed claims and the `/status` endpoint
+returns processing counts so you can display a real-time indicator in the UI.
+
 ## Tests
 Tests use `pytest`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ joblib
 PyYAML
 durable_rules
 scikit-learn
+fastapi
+uvicorn

--- a/src/processing/pipeline.py
+++ b/src/processing/pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from typing import List, Dict, Any
 
 from ..config.config import AppConfig
@@ -10,6 +11,7 @@ from ..rules.durable_engine import DurableRulesEngine
 from ..validation.validator import ClaimValidator
 from ..utils.cache import InMemoryCache
 from ..utils.logging import setup_logging, RequestContextFilter
+from ..web.status import processing_status
 
 
 class ClaimsPipeline:
@@ -34,7 +36,11 @@ class ClaimsPipeline:
         request_filter = RequestContextFilter()
         self.logger.addFilter(request_filter)
 
-        claims = await self.pg.fetch("SELECT * FROM claims LIMIT $1", self.cfg.processing.batch_size)
+        processing_status["processed"] = 0
+        processing_status["failed"] = 0
+        claims = await self.pg.fetch(
+            "SELECT * FROM claims LIMIT $1", self.cfg.processing.batch_size
+        )
         tasks = [self.process_claim(claim) for claim in claims]
         await asyncio.gather(*tasks)
 
@@ -43,10 +49,35 @@ class ClaimsPipeline:
         validation_errors = self.validator.validate(claim)
         rule_errors = self.rules_engine.evaluate(claim)
         if validation_errors or rule_errors:
-            self.logger.error(f"Claim {claim['claim_id']} failed validation", extra={"request_id": claim.get("correlation_id")})
+            processing_status["failed"] += 1
+            await self.record_failed_claim(claim, "validation")
+            self.logger.error(
+                f"Claim {claim['claim_id']} failed validation",
+                extra={"request_id": claim.get("correlation_id")},
+            )
             return
         prediction = self.model.predict(claim)
         claim["filter_number"] = prediction
         # Insert into SQL Server
-        await self.sql.execute("INSERT INTO claims (patient_account_number, facility_id) VALUES (?, ?)", claim["patient_account_number"], claim["facility_id"])
-        self.logger.info(f"Processed claim {claim['claim_id']}", extra={"request_id": claim.get("correlation_id")})
+        await self.sql.execute(
+            "INSERT INTO claims (patient_account_number, facility_id) VALUES (?, ?)",
+            claim["patient_account_number"],
+            claim["facility_id"],
+        )
+        processing_status["processed"] += 1
+        self.logger.info(
+            f"Processed claim {claim['claim_id']}",
+            extra={"request_id": claim.get("correlation_id")},
+        )
+
+    async def record_failed_claim(self, claim: Dict[str, Any], reason: str) -> None:
+        await self.sql.execute(
+            "INSERT INTO failed_claims (claim_id, facility_id, patient_account_number, failure_reason, processing_stage, failed_at, original_data)"
+            " VALUES (?, ?, ?, ?, ?, GETDATE(), ?)",
+            claim.get("claim_id"),
+            claim.get("facility_id"),
+            claim.get("patient_account_number"),
+            reason,
+            "validation",
+            json.dumps(claim),
+        )

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from ..config.config import load_config
+from ..db.sql_server import SQLServerDatabase
+from .status import processing_status
+from typing import Optional
+
+
+def create_app(sql_db: Optional[SQLServerDatabase] = None) -> FastAPI:
+    app = FastAPI()
+    cfg = load_config()
+    sql = sql_db or SQLServerDatabase(cfg.sqlserver)
+
+    @app.on_event("startup")
+    async def startup() -> None:
+        await sql.connect()
+
+    @app.get("/api/failed_claims")
+    async def api_failed_claims():
+        rows = await sql.fetch(
+            "SELECT TOP 100 * FROM failed_claims ORDER BY failed_at DESC"
+        )
+        return rows
+
+    @app.get("/failed_claims", response_class=HTMLResponse)
+    async def failed_claims_page():
+        rows = await sql.fetch(
+            "SELECT TOP 100 * FROM failed_claims ORDER BY failed_at DESC"
+        )
+        html_rows = "".join(
+            f"<tr><td>{r.get('claim_id')}</td><td>{r.get('failure_reason')}</td><td>{r.get('failed_at')}</td></tr>"
+            for r in rows
+        )
+        page = f"""
+        <html>
+        <head><title>Failed Claims</title></head>
+        <body>
+        <h1>Failed Claims</h1>
+        <table>
+        <tr><th>Claim ID</th><th>Reason</th><th>Failed At</th></tr>
+        {html_rows}
+        </table>
+        </body>
+        </html>
+        """
+        return HTMLResponse(content=page)
+
+    @app.get("/status")
+    async def status():
+        return processing_status
+
+    return app
+
+
+app = create_app()

--- a/src/web/status.py
+++ b/src/web/status.py
@@ -1,0 +1,1 @@
+processing_status = {"processed": 0, "failed": 0}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,35 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.web.app import create_app
+from src.web.status import processing_status
+
+class DummyDB:
+    async def connect(self):
+        pass
+
+    async def fetch(self, query: str, *params):
+        return [{"claim_id": "1", "failure_reason": "bad data", "failed_at": "now"}]
+
+    async def execute(self, query: str, *params):
+        return 1
+
+@pytest.fixture
+def client():
+    app = create_app(sql_db=DummyDB())
+    with TestClient(app) as client:
+        yield client
+
+
+def test_failed_claims_endpoint(client):
+    resp = client.get("/api/failed_claims")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["claim_id"] == "1"
+
+
+def test_status_endpoint(client):
+    processing_status["processed"] = 5
+    processing_status["failed"] = 2
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"processed": 5, "failed": 2}


### PR DESCRIPTION
## Summary
- add FastAPI and uvicorn dependencies
- build basic FastAPI app with UI to list failed claims
- expose processing status API and hook pipeline updates
- track processed/failed counts
- document real-time web UI in README
- add tests for new endpoints

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684c3908e46c832a9440c863c1b9e6f8