### PR TITLE
Add robust error handling and health checks

### DIFF
--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -1,6 +1,8 @@
 import asyncpg
 from typing import Iterable, Any
 
+from ..utils.errors import DatabaseConnectionError, QueryError
+
 from .base import BaseDatabase
 from ..config.config import PostgresConfig
 
@@ -11,32 +13,72 @@ class PostgresDatabase(BaseDatabase):
         self.pool: asyncpg.pool.Pool | None = None
 
     async def connect(self) -> None:
-        self.pool = await asyncpg.create_pool(
-            host=self.cfg.host,
-            port=self.cfg.port,
-            user=self.cfg.user,
-            password=self.cfg.password,
-            database=self.cfg.database,
-            min_size=5,
-            max_size=20,
-        )
+        try:
+            self.pool = await asyncpg.create_pool(
+                host=self.cfg.host,
+                port=self.cfg.port,
+                user=self.cfg.user,
+                password=self.cfg.password,
+                database=self.cfg.database,
+                min_size=5,
+                max_size=20,
+            )
+        except Exception as e:
+            raise DatabaseConnectionError(str(e)) from e
+
+    async def _ensure_pool(self) -> None:
+        if not self.pool:
+            await self.connect()
 
     async def fetch(self, query: str, *params: Any) -> Iterable[dict]:
+        await self._ensure_pool()
         assert self.pool
-        async with self.pool.acquire() as conn:
-            rows = await conn.fetch(query, *params)
-            return [dict(row) for row in rows]
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(query, *params)
+                return [dict(row) for row in rows]
+        except asyncpg.PostgresError:
+            await self.connect()
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(query, *params)
+                return [dict(row) for row in rows]
+        except Exception as e:
+            raise QueryError(str(e)) from e
 
     async def execute(self, query: str, *params: Any) -> int:
+        await self._ensure_pool()
         assert self.pool
-        async with self.pool.acquire() as conn:
-            result = await conn.execute(query, *params)
-            return int(result.split(" ")[-1])
+        try:
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(query, *params)
+                return int(result.split(" ")[-1])
+        except asyncpg.PostgresError:
+            await self.connect()
+            async with self.pool.acquire() as conn:
+                result = await conn.execute(query, *params)
+                return int(result.split(" ")[-1])
+        except Exception as e:
+            raise QueryError(str(e)) from e
 
     async def execute_many(self, query: str, params_seq: Iterable[Iterable[Any]]) -> int:
+        await self._ensure_pool()
         assert self.pool
         params_list = list(params_seq)
-        async with self.pool.acquire() as conn:
-            await conn.executemany(query, params_list)
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.executemany(query, params_list)
+        except asyncpg.PostgresError:
+            await self.connect()
+            async with self.pool.acquire() as conn:
+                await conn.executemany(query, params_list)
+        except Exception as e:
+            raise QueryError(str(e)) from e
         return len(params_list)
+
+    async def health_check(self) -> bool:
+        try:
+            await self.fetch("SELECT 1")
+            return True
+        except DatabaseError:
+            return False
 

--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -2,6 +2,8 @@ import asyncio
 import pyodbc
 from typing import Iterable, Any
 
+from ..utils.errors import DatabaseConnectionError, QueryError
+
 from .base import BaseDatabase
 from ..config.config import SQLServerConfig
 
@@ -13,17 +15,25 @@ class SQLServerDatabase(BaseDatabase):
         self._lock = asyncio.Lock()
 
     async def connect(self, size: int = 5) -> None:
-        for _ in range(size):
-            conn = pyodbc.connect(
-                f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={self.cfg.host},{self.cfg.port};"
-                f"DATABASE={self.cfg.database};UID={self.cfg.user};PWD={self.cfg.password}",
-                autocommit=False,
-            )
-            self.pool.append(conn)
+        try:
+            for _ in range(size):
+                conn = self._create_connection()
+                self.pool.append(conn)
+        except Exception as e:
+            raise DatabaseConnectionError(str(e)) from e
+
+    def _create_connection(self) -> pyodbc.Connection:
+        return pyodbc.connect(
+            f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={self.cfg.host},{self.cfg.port};"
+            f"DATABASE={self.cfg.database};UID={self.cfg.user};PWD={self.cfg.password}",
+            autocommit=False,
+        )
 
     async def _acquire(self) -> pyodbc.Connection:
         async with self._lock:
-            return self.pool.pop() if self.pool else None
+            if self.pool:
+                return self.pool.pop()
+            return self._create_connection()
 
     async def _release(self, conn: pyodbc.Connection) -> None:
         async with self._lock:
@@ -31,28 +41,68 @@ class SQLServerDatabase(BaseDatabase):
 
     async def fetch(self, query: str, *params: Any) -> Iterable[dict]:
         conn = await self._acquire()
-        cursor = conn.cursor()
-        cursor.execute(query, params)
-        columns = [col[0] for col in cursor.description]
-        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
-        await self._release(conn)
-        return rows
+        try:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            columns = [col[0] for col in cursor.description]
+            rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+            return rows
+        except pyodbc.Error:
+            conn.close()
+            conn = self._create_connection()
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            columns = [col[0] for col in cursor.description]
+            rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+            return rows
+        except Exception as e:
+            raise QueryError(str(e)) from e
+        finally:
+            await self._release(conn)
 
     async def execute(self, query: str, *params: Any) -> int:
         conn = await self._acquire()
-        cursor = conn.cursor()
-        cursor.execute(query, params)
-        conn.commit()
-        rowcount = cursor.rowcount
-        await self._release(conn)
-        return rowcount
+        try:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            conn.commit()
+            return cursor.rowcount
+        except pyodbc.Error:
+            conn.close()
+            conn = self._create_connection()
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            conn.commit()
+            return cursor.rowcount
+        except Exception as e:
+            raise QueryError(str(e)) from e
+        finally:
+            await self._release(conn)
 
     async def execute_many(self, query: str, params_seq: Iterable[Iterable[Any]]) -> int:
         conn = await self._acquire()
-        cursor = conn.cursor()
-        cursor.executemany(query, list(params_seq))
-        conn.commit()
-        rowcount = cursor.rowcount
-        await self._release(conn)
-        return rowcount
+        params_list = list(params_seq)
+        try:
+            cursor = conn.cursor()
+            cursor.executemany(query, params_list)
+            conn.commit()
+            return cursor.rowcount
+        except pyodbc.Error:
+            conn.close()
+            conn = self._create_connection()
+            cursor = conn.cursor()
+            cursor.executemany(query, params_list)
+            conn.commit()
+            return cursor.rowcount
+        except Exception as e:
+            raise QueryError(str(e)) from e
+        finally:
+            await self._release(conn)
+
+    async def health_check(self) -> bool:
+        try:
+            await self.execute("SELECT 1")
+            return True
+        except DatabaseError:
+            return False
 

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -1,0 +1,9 @@
+class DatabaseError(Exception):
+    """Base class for database related errors."""
+
+class DatabaseConnectionError(DatabaseError):
+    """Raised when a database connection cannot be established."""
+
+class QueryError(DatabaseError):
+    """Raised when a query execution fails."""
+

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -49,6 +49,11 @@ def create_app(sql_db: Optional[SQLServerDatabase] = None) -> FastAPI:
     async def status():
         return processing_status
 
+    @app.get("/health")
+    async def health():
+        ok = await sql.health_check()
+        return {"sqlserver": ok}
+
     return app
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -13,6 +13,9 @@ class DummyDB:
     async def execute(self, query: str, *params):
         return 1
 
+    async def health_check(self):
+        return True
+
 @pytest.fixture
 def client():
     app = create_app(sql_db=DummyDB())
@@ -33,3 +36,9 @@ def test_status_endpoint(client):
     resp = client.get("/status")
     assert resp.status_code == 200
     assert resp.json() == {"processed": 5, "failed": 2}
+
+
+def test_health_endpoint(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"sqlserver": True}


### PR DESCRIPTION
## Summary
- introduce standard database error classes
- add automatic reconnection and health check methods for databases
- expose `/health` endpoint in FastAPI app
- test new endpoint and update dummy DB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684c3cf77bac832a9476e86d910d98df