### PR TITLE
Add structured logging and auditing

### DIFF
--- a/src/utils/audit.py
+++ b/src/utils/audit.py
@@ -1,0 +1,32 @@
+import json
+from typing import Any, Optional
+
+from ..db.sql_server import SQLServerDatabase
+
+
+async def record_audit_event(
+    db: SQLServerDatabase,
+    table_name: str,
+    record_id: str,
+    operation: str,
+    user_id: Optional[str] = None,
+    old_values: Optional[dict[str, Any]] = None,
+    new_values: Optional[dict[str, Any]] = None,
+    reason: Optional[str] = None,
+) -> None:
+    """Persist an audit trail entry to the audit_log table."""
+    await db.execute(
+        """
+        INSERT INTO audit_log (
+            table_name, record_id, operation, user_id,
+            old_values, new_values, operation_timestamp, reason
+        ) VALUES (?, ?, ?, ?, ?, ?, GETDATE(), ?)
+        """,
+        table_name,
+        record_id,
+        operation,
+        user_id,
+        json.dumps(old_values) if old_values else None,
+        json.dumps(new_values) if new_values else None,
+        reason,
+    )

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,9 +1,30 @@
 import logging
+import json
 import uuid
 
 
-def setup_logging() -> logging.Logger:
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON for analytics."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting only
+        standard = logging.makeLogRecord({}).__dict__.keys()
+        data = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", ""),
+        }
+        for key, value in record.__dict__.items():
+            if key not in standard and key not in data:
+                data[key] = value
+        return json.dumps(data)
+
+
+def setup_logging(request_id: str | None = None) -> logging.Logger:
     logger = logging.getLogger("claims_processor")
+    if logger.handlers:
+        return logger
+
     stream_handler = logging.StreamHandler()
     fmt = logging.Formatter(
         "%(asctime)s [%(levelname)s] %(request_id)s %(message)s"
@@ -14,7 +35,13 @@ def setup_logging() -> logging.Logger:
     file_handler = logging.FileHandler("audit.log")
     file_handler.setFormatter(fmt)
     logger.addHandler(file_handler)
+
+    analytics_handler = logging.FileHandler("analytics.log")
+    analytics_handler.setFormatter(JsonFormatter())
+    logger.addHandler(analytics_handler)
+
     logger.setLevel(logging.INFO)
+    logger.addFilter(RequestContextFilter(request_id))
     return logger
 
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,16 @@
+from src.security.compliance import mask_claim_data
+
+
+def test_mask_claim_data():
+    claim = {
+        "patient_name": "Jane Doe",
+        "patient_account_number": "123456",
+        "date_of_birth": "1990-01-01",
+        "other": "value",
+    }
+    masked = mask_claim_data(claim)
+    assert masked["patient_name"] == "***"
+    assert masked["patient_account_number"].startswith("12")
+    assert masked["patient_account_number"].endswith("***")
+    assert masked["date_of_birth"] == "***"
+    assert masked["other"] == "value"


### PR DESCRIPTION
## Summary
- implement `JsonFormatter` and add analytics log handler
- integrate `RequestContextFilter`
- mask claim data before logging
- create audit utility to record events
- log audit events on claim insert and failure
- add unit test for `mask_claim_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c433c193c832a92f13f7bf0d89388