### PR TITLE
Add request tracing with correlation IDs

### DIFF
--- a/src/utils/tracing.py
+++ b/src/utils/tracing.py
@@ -1,0 +1,23 @@
+import uuid
+from contextvars import ContextVar
+from contextlib import contextmanager
+
+trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
+span_id_var: ContextVar[str] = ContextVar("span_id", default="")
+
+
+def start_trace(trace_id: str | None = None) -> str:
+    """Start a new trace and set the trace_id context variable."""
+    trace = trace_id or str(uuid.uuid4())
+    trace_id_var.set(trace)
+    return trace
+
+
+@contextmanager
+def start_span(span_id: str | None = None):
+    """Context manager to set a span_id for the duration of the block."""
+    token = span_id_var.set(span_id or str(uuid.uuid4()))
+    try:
+        yield
+    finally:
+        span_id_var.reset(token)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.web.app import create_app
+
+class DummyDB:
+    async def connect(self):
+        pass
+
+    async def fetch(self, query: str, *params):
+        return []
+
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def health_check(self):
+        return True
+
+@pytest.fixture
+def client():
+    app = create_app(sql_db=DummyDB(), api_key="test")
+    with TestClient(app) as client:
+        yield client
+
+def test_trace_id_header(client):
+    resp = client.get("/health", headers={"X-API-Key": "test"})
+    assert resp.status_code == 200
+    assert "X-Trace-ID" in resp.headers
+    assert resp.headers["X-Trace-ID"]


### PR DESCRIPTION
## Summary
- implement contextvar-based tracing utilities
- log `trace_id` and `span_id`
- propagate trace information in pipeline and FastAPI app
- test presence of trace header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_684c459d5774832aa104a519af1f757e