### PR TITLE
Add integration test and benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ Tests use `pytest`.
 
 ```bash
 pip install pytest
-pytest
+PYTHONPATH=. pytest
 ```
 
 Add new tests under the `tests/` directory using files named `test_*.py`.
+
+## Benchmarks
+Simple performance benchmarks live in the `benchmarks/` directory.
+Run the pipeline benchmark script with:
+
+```bash
+python benchmarks/benchmark_pipeline.py
+```
 
 ## Contributing
 Contributions are welcome! Please open an issue to discuss any changes. Ensure tests pass before submitting a pull request and follow PEP 8 style conventions.

--- a/benchmarks/benchmark_pipeline.py
+++ b/benchmarks/benchmark_pipeline.py
@@ -1,0 +1,69 @@
+import asyncio
+import time
+
+from src.processing.pipeline import ClaimsPipeline
+from src.config.config import AppConfig, PostgresConfig, SQLServerConfig, ProcessingConfig, SecurityConfig, CacheConfig, ModelConfig
+from src.services.claim_service import ClaimService
+from src.rules.engine import RulesEngine
+from src.validation.validator import ClaimValidator
+
+class DummyPostgres:
+    async def fetch(self, query: str, *params):
+        return [{
+            "claim_id": "1",
+            "patient_account_number": "111",
+            "facility_id": "F1",
+            "procedure_code": "P1"
+        }]
+
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        return len(list(params_seq))
+
+class DummySQL:
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        return len(list(params_seq))
+
+class DummyModel:
+    def predict(self, claim):
+        return 1
+
+def create_pipeline():
+    cfg = AppConfig(
+        postgres=PostgresConfig("", 0, "", "", ""),
+        sqlserver=SQLServerConfig("", 0, "", "", ""),
+        processing=ProcessingConfig(batch_size=1),
+        security=SecurityConfig(api_key="k"),
+        cache=CacheConfig(),
+        model=ModelConfig(path="model.joblib"),
+    )
+    pipeline = ClaimsPipeline(cfg)
+    pipeline.pg = DummyPostgres()
+    pipeline.sql = DummySQL()
+    pipeline.model = DummyModel()
+    pipeline.rules_engine = RulesEngine([])
+    pipeline.validator = ClaimValidator({"F1"}, set())
+    pipeline.service = ClaimService(pipeline.pg, pipeline.sql)
+    return pipeline
+
+async def run(iterations: int = 1000) -> float:
+    pipeline = create_pipeline()
+    claim = {
+        "claim_id": "1",
+        "patient_account_number": "111",
+        "facility_id": "F1",
+        "procedure_code": "P1"
+    }
+    start = time.perf_counter()
+    for _ in range(iterations):
+        await pipeline.process_claim(claim)
+    return time.perf_counter() - start
+
+if __name__ == "__main__":
+    duration = asyncio.run(run())
+    print(f"Processed 1000 claims in {duration:.4f}s")

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,96 @@
+import pytest
+import sys
+import types
+import asyncio
+
+sys.modules.setdefault("asyncpg", types.ModuleType("asyncpg"))
+sys.modules.setdefault("joblib", types.ModuleType("joblib"))
+durable_module = types.ModuleType("durable")
+durable_lang = types.ModuleType("lang")
+durable_lang.ruleset = lambda name: (lambda func: func)
+durable_lang.when_all = lambda cond: (lambda func: func)
+durable_lang.m = object()
+durable_lang.post = lambda name, data: None
+setattr(durable_module, "lang", durable_lang)
+sys.modules.setdefault("durable", durable_module)
+sys.modules.setdefault("durable.lang", durable_lang)
+
+from src.processing.pipeline import ClaimsPipeline
+from src.config.config import AppConfig, PostgresConfig, SQLServerConfig, ProcessingConfig, SecurityConfig, CacheConfig, ModelConfig
+from src.services.claim_service import ClaimService
+from src.rules.engine import RulesEngine
+from src.validation.validator import ClaimValidator
+from src.web.status import processing_status
+
+class DummyPostgres:
+    async def connect(self):
+        pass
+
+    async def fetch(self, query: str, *params):
+        return [{
+            "claim_id": "1",
+            "patient_account_number": "111",
+            "facility_id": "F1",
+            "procedure_code": "P1",
+            "financial_class": "A"
+        }]
+
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        return len(list(params_seq))
+
+class DummySQL:
+    def __init__(self):
+        self.inserted = []
+
+    async def connect(self):
+        pass
+
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        items = list(params_seq)
+        self.inserted.extend(items)
+        return len(items)
+
+    async def prepare(self, query: str):
+        pass
+
+async def noop(*args, **kwargs):
+    pass
+
+class DummyModel:
+    def predict(self, claim):
+        return 1
+
+def test_pipeline_process_batch(monkeypatch):
+    cfg = AppConfig(
+        postgres=PostgresConfig("", 0, "", "", ""),
+        sqlserver=SQLServerConfig("", 0, "", "", ""),
+        processing=ProcessingConfig(batch_size=1),
+        security=SecurityConfig(api_key="k"),
+        cache=CacheConfig(),
+        model=ModelConfig(path="model.joblib"),
+    )
+    pipeline = ClaimsPipeline(cfg)
+    pipeline.pg = DummyPostgres()
+    pipeline.sql = DummySQL()
+    pipeline.model = DummyModel()
+    pipeline.rules_engine = RulesEngine([])
+    pipeline.validator = ClaimValidator({"F1"}, {"A"})
+    pipeline.service = ClaimService(pipeline.pg, pipeline.sql)
+    monkeypatch.setattr("src.utils.audit.record_audit_event", noop)
+    processing_status["processed"] = 0
+    processing_status["failed"] = 0
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(pipeline.process_batch())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    assert processing_status["processed"] == 1
+    assert pipeline.sql.inserted == [("111", "F1")]


### PR DESCRIPTION
## Summary
- add pipeline integration test
- add simple benchmark script for the pipeline
- document running tests via `PYTHONPATH` and running benchmarks

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4ac968ac832a889ba6871a8472f1