### PR TITLE
Add migrations and monitoring tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ pip install -r requirements.txt
 ### PostgreSQL
 1. Create a database named `staging_process`.
 2. Apply the tables described in [docs/SCHEMA.md](docs/SCHEMA.md).
+ 3. Run the migrations with `alembic upgrade head` to apply updates.
 
 ### SQL Server
 1. Create a database named `smart_pro_claims`.
 2. Apply the tables described in [docs/SCHEMA.md](docs/SCHEMA.md).
 
 Update `config.yaml` with your connection details.
+If you have a read replica for PostgreSQL, set `replica_host` and `replica_port` in that file.
 
 Set the `APP_ENV` environment variable to load `config.<environment>.yaml` or
 `APP_CONFIG` to specify an explicit configuration file. When neither is set,
@@ -57,6 +59,8 @@ uvicorn src.web.app:app --reload
 
 The `/failed_claims` page lists recent failed claims and the `/status` endpoint
 returns processing counts so you can display a real-time indicator in the UI.
+Database and query metrics are exposed from the `/metrics` endpoint for
+operational monitoring.
 
 ## Tests
 Tests use `pytest`.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql://user:pass@localhost:5432/staging_process
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ postgresql:
   user: user
   password: pass
   database: staging_process
+  replica_host: null
+  replica_port: null
 sqlserver:
   host: localhost
   port: 1433

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,21 @@
+# Database Migrations
+
+This project uses **Alembic** for schema migrations. Install dependencies:
+
+```bash
+pip install alembic
+```
+
+Create new revisions with:
+
+```bash
+alembic revision -m "description"
+```
+
+Apply migrations using:
+
+```bash
+alembic upgrade head
+```
+
+The configuration is provided in `alembic.ini` and migrations live under `migrations/versions`.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,32 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+
+config = context.config
+fileConfig(config.config_file_name)
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ fastapi
 uvicorn
 cryptography
 redis
+alembic

--- a/sql/create_indexes.sql
+++ b/sql/create_indexes.sql
@@ -1,0 +1,10 @@
+-- Indexes for PostgreSQL
+CREATE INDEX IF NOT EXISTS idx_claims_claim_id ON claims (claim_id);
+CREATE INDEX IF NOT EXISTS idx_failed_claims_claim_id ON failed_claims (claim_id);
+
+-- Indexes for SQL Server
+GO
+CREATE INDEX idx_sql_claims_claim_id ON claims (claim_id);
+GO
+CREATE INDEX idx_sql_failed_claims_claim_id ON failed_claims (claim_id);
+GO

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -41,6 +41,8 @@ class PostgresConfig:
     user: str
     password: str
     database: str
+    replica_host: Optional[str] = None
+    replica_port: Optional[int] = None
 
 
 @dataclass

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -1,0 +1,31 @@
+"""Simple wrapper around Alembic commands."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+
+from ..config.config import PostgresConfig
+
+
+async def apply_migrations(cfg: PostgresConfig) -> None:
+    """Run ``alembic upgrade head`` using the given configuration."""
+    ini_path = Path(__file__).resolve().parent.parent.parent / "alembic.ini"
+    env = dict(os.environ)
+    env["DATABASE_URL"] = (
+        f"postgresql://{cfg.user}:{cfg.password}@{cfg.host}:{cfg.port}/{cfg.database}"
+    )
+    subprocess.run(
+        ["alembic", "-c", str(ini_path), "upgrade", "head"], check=True, env=env
+    )
+
+
+if __name__ == "__main__":
+    import os
+    from ..config.config import load_config
+
+    config_path = os.getenv("APP_CONFIG", "config.yaml")
+    cfg = load_config(config_path)
+    asyncio.run(apply_migrations(cfg.postgres))

--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -1,16 +1,20 @@
 import asyncpg
 from typing import Iterable, Any
 
+import time
+
 from ..utils.errors import DatabaseConnectionError, QueryError
 
 from .base import BaseDatabase
 from ..config.config import PostgresConfig
+from ..monitoring.metrics import metrics
 
 
 class PostgresDatabase(BaseDatabase):
     def __init__(self, cfg: PostgresConfig):
         self.cfg = cfg
         self.pool: asyncpg.pool.Pool | None = None
+        self.replica_pool: asyncpg.pool.Pool | None = None
 
     async def connect(self) -> None:
         try:
@@ -23,25 +27,44 @@ class PostgresDatabase(BaseDatabase):
                 min_size=5,
                 max_size=20,
             )
+            if self.cfg.replica_host:
+                self.replica_pool = await asyncpg.create_pool(
+                    host=self.cfg.replica_host,
+                    port=self.cfg.replica_port or self.cfg.port,
+                    user=self.cfg.user,
+                    password=self.cfg.password,
+                    database=self.cfg.database,
+                    min_size=5,
+                    max_size=20,
+                )
         except Exception as e:
             raise DatabaseConnectionError(str(e)) from e
 
     async def _ensure_pool(self) -> None:
         if not self.pool:
             await self.connect()
+        if self.cfg.replica_host and not self.replica_pool:
+            await self.connect()
 
     async def fetch(self, query: str, *params: Any) -> Iterable[dict]:
         await self._ensure_pool()
         assert self.pool
         try:
-            async with self.pool.acquire() as conn:
+            pool = self.replica_pool or self.pool
+            assert pool
+            start = time.perf_counter()
+            async with pool.acquire() as conn:
                 rows = await conn.fetch(query, *params)
-                return [dict(row) for row in rows]
+            duration = (time.perf_counter() - start) * 1000
+            metrics.inc("postgres_query_ms", duration)
+            return [dict(row) for row in rows]
         except asyncpg.PostgresError:
             await self.connect()
-            async with self.pool.acquire() as conn:
+            pool = self.replica_pool or self.pool
+            assert pool
+            async with pool.acquire() as conn:
                 rows = await conn.fetch(query, *params)
-                return [dict(row) for row in rows]
+            return [dict(row) for row in rows]
         except Exception as e:
             raise QueryError(str(e)) from e
 
@@ -49,24 +72,32 @@ class PostgresDatabase(BaseDatabase):
         await self._ensure_pool()
         assert self.pool
         try:
+            start = time.perf_counter()
             async with self.pool.acquire() as conn:
                 result = await conn.execute(query, *params)
-                return int(result.split(" ")[-1])
+            duration = (time.perf_counter() - start) * 1000
+            metrics.inc("postgres_query_ms", duration)
+            return int(result.split(" ")[-1])
         except asyncpg.PostgresError:
             await self.connect()
             async with self.pool.acquire() as conn:
                 result = await conn.execute(query, *params)
-                return int(result.split(" ")[-1])
+            return int(result.split(" ")[-1])
         except Exception as e:
             raise QueryError(str(e)) from e
 
-    async def execute_many(self, query: str, params_seq: Iterable[Iterable[Any]]) -> int:
+    async def execute_many(
+        self, query: str, params_seq: Iterable[Iterable[Any]]
+    ) -> int:
         await self._ensure_pool()
         assert self.pool
         params_list = list(params_seq)
         try:
+            start = time.perf_counter()
             async with self.pool.acquire() as conn:
                 await conn.executemany(query, params_list)
+            duration = (time.perf_counter() - start) * 1000
+            metrics.inc("postgres_query_ms", duration)
         except asyncpg.PostgresError:
             await self.connect()
             async with self.pool.acquire() as conn:
@@ -82,3 +113,13 @@ class PostgresDatabase(BaseDatabase):
         except DatabaseError:
             return False
 
+    def report_pool_status(self) -> None:
+        if not self.pool:
+            return
+        try:
+            in_use = self.pool._working_conn_count  # type: ignore[attr-defined]
+            max_size = self.pool._maxsize  # type: ignore[attr-defined]
+            metrics.set("postgres_pool_in_use", float(in_use))
+            metrics.set("postgres_pool_max", float(max_size))
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- introduce Alembic configuration under `migrations/`
- add a convenience migration runner
- allow specifying a PostgreSQL read replica
- track connection pool usage and query timings
- document migrations, metrics and replica settings
- provide sample index creation script

## Testing
- `black -q .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53193180832abb1fdb2004e43676