### PR TITLE
Add shutdown, circuit breaker, and rate limiting

### DIFF
--- a/src/db/base.py
+++ b/src/db/base.py
@@ -11,3 +11,7 @@ class BaseDatabase:
     async def execute_many(self, query: str, params_seq: Iterable[Iterable[Any]]) -> int:
         """Execute a statement against many parameter sets."""
         raise NotImplementedError
+
+    async def close(self) -> None:
+        """Close any underlying connection pools."""
+        raise NotImplementedError

--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -3,7 +3,8 @@ import time
 import pyodbc
 from typing import Iterable, Any
 
-from ..utils.errors import DatabaseConnectionError, QueryError
+from ..utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpenError
+from ..utils.errors import DatabaseConnectionError, QueryError, CircuitBreakerOpenError
 
 from .base import BaseDatabase
 from ..config.config import SQLServerConfig
@@ -16,8 +17,11 @@ class SQLServerDatabase(BaseDatabase):
         self.pool: list[pyodbc.Connection] = []
         self._lock = asyncio.Lock()
         self._prepared: dict[str, str] = {}
+        self.circuit_breaker = CircuitBreaker()
 
     async def connect(self, size: int = 5) -> None:
+        if not await self.circuit_breaker.allow():
+            raise CircuitBreakerOpenError("SQLServer circuit open")
         try:
             for _ in range(size):
                 conn = self._create_connection()
@@ -26,7 +30,9 @@ class SQLServerDatabase(BaseDatabase):
                 cursor.execute("SELECT 1")
                 self.pool.append(conn)
         except Exception as e:
+            await self.circuit_breaker.record_failure()
             raise DatabaseConnectionError(str(e)) from e
+        await self.circuit_breaker.record_success()
 
     def _create_connection(self) -> pyodbc.Connection:
         return pyodbc.connect(
@@ -59,6 +65,8 @@ class SQLServerDatabase(BaseDatabase):
             await self._release(conn)
 
     async def fetch(self, query: str, *params: Any) -> Iterable[dict]:
+        if not await self.circuit_breaker.allow():
+            raise CircuitBreakerOpenError("SQLServer circuit open")
         conn = await self._acquire()
         try:
             start = time.perf_counter()
@@ -68,6 +76,7 @@ class SQLServerDatabase(BaseDatabase):
             rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            await self.circuit_breaker.record_success()
             return rows
         except pyodbc.Error:
             conn.close()
@@ -76,13 +85,17 @@ class SQLServerDatabase(BaseDatabase):
             cursor.execute(query, params)
             columns = [col[0] for col in cursor.description]
             rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+            await self.circuit_breaker.record_success()
             return rows
         except Exception as e:
+            await self.circuit_breaker.record_failure()
             raise QueryError(str(e)) from e
         finally:
             await self._release(conn)
 
     async def execute(self, query: str, *params: Any) -> int:
+        if not await self.circuit_breaker.allow():
+            raise CircuitBreakerOpenError("SQLServer circuit open")
         conn = await self._acquire()
         try:
             start = time.perf_counter()
@@ -94,6 +107,7 @@ class SQLServerDatabase(BaseDatabase):
             conn.commit()
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            await self.circuit_breaker.record_success()
             return cursor.rowcount
         except pyodbc.Error:
             conn.close()
@@ -104,8 +118,10 @@ class SQLServerDatabase(BaseDatabase):
             else:
                 cursor.execute(query, params)
             conn.commit()
+            await self.circuit_breaker.record_success()
             return cursor.rowcount
         except Exception as e:
+            await self.circuit_breaker.record_failure()
             raise QueryError(str(e)) from e
         finally:
             await self._release(conn)
@@ -113,6 +129,8 @@ class SQLServerDatabase(BaseDatabase):
     async def execute_many(
         self, query: str, params_seq: Iterable[Iterable[Any]]
     ) -> int:
+        if not await self.circuit_breaker.allow():
+            raise CircuitBreakerOpenError("SQLServer circuit open")
         conn = await self._acquire()
         params_list = list(params_seq)
         try:
@@ -126,6 +144,7 @@ class SQLServerDatabase(BaseDatabase):
             conn.commit()
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            await self.circuit_breaker.record_success()
             return cursor.rowcount
         except pyodbc.Error:
             conn.close()
@@ -137,18 +156,30 @@ class SQLServerDatabase(BaseDatabase):
             else:
                 cursor.executemany(query, params_list)
             conn.commit()
+            await self.circuit_breaker.record_success()
             return cursor.rowcount
         except Exception as e:
+            await self.circuit_breaker.record_failure()
             raise QueryError(str(e)) from e
         finally:
             await self._release(conn)
 
     async def health_check(self) -> bool:
+        if not await self.circuit_breaker.allow():
+            return False
         try:
             await self.execute("SELECT 1")
+            await self.circuit_breaker.record_success()
             return True
         except DatabaseError:
+            await self.circuit_breaker.record_failure()
             return False
 
     def report_pool_status(self) -> None:
         metrics.set("sqlserver_pool_size", float(len(self.pool)))
+
+    async def close(self) -> None:
+        async with self._lock:
+            while self.pool:
+                conn = self.pool.pop()
+                conn.close()

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -1,0 +1,37 @@
+import asyncio
+import time
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when the circuit breaker is open."""
+
+
+class CircuitBreaker:
+    """Simple async circuit breaker."""
+
+    def __init__(self, failure_threshold: int = 3, recovery_time: float = 30.0):
+        self.failure_threshold = failure_threshold
+        self.recovery_time = recovery_time
+        self.failure_count = 0
+        self.open_until: float | None = None
+        self._lock = asyncio.Lock()
+
+    async def allow(self) -> bool:
+        async with self._lock:
+            if self.open_until is None:
+                return True
+            if time.monotonic() >= self.open_until:
+                self.failure_count = 0
+                self.open_until = None
+                return True
+            return False
+
+    async def record_success(self) -> None:
+        async with self._lock:
+            self.failure_count = 0
+            self.open_until = None
+
+    async def record_failure(self) -> None:
+        async with self._lock:
+            self.failure_count += 1
+            if self.failure_count >= self.failure_threshold:
+                self.open_until = time.monotonic() + self.recovery_time

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -7,3 +7,7 @@ class DatabaseConnectionError(DatabaseError):
 class QueryError(DatabaseError):
     """Raised when a query execution fails."""
 
+
+class CircuitBreakerOpenError(DatabaseError):
+    """Raised when the circuit breaker is open and operations are blocked."""
+

--- a/src/web/rate_limit.py
+++ b/src/web/rate_limit.py
@@ -1,0 +1,23 @@
+import asyncio
+import time
+
+class RateLimiter:
+    def __init__(self, rate: int = 100, per: float = 1.0):
+        self.rate = rate
+        self.per = per
+        self.allowance = rate
+        self.last_check = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def allow(self) -> bool:
+        async with self._lock:
+            current = time.monotonic()
+            elapsed = current - self.last_check
+            self.last_check = current
+            self.allowance += elapsed * (self.rate / self.per)
+            if self.allowance > self.rate:
+                self.allowance = self.rate
+            if self.allowance < 1.0:
+                return False
+            self.allowance -= 1.0
+            return True

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,15 @@
+import asyncio
+from src.utils.circuit_breaker import CircuitBreaker
+
+
+def test_circuit_breaker_blocks_after_failures():
+    async def run():
+        cb = CircuitBreaker(failure_threshold=2, recovery_time=0.1)
+        assert await cb.allow()
+        await cb.record_failure()
+        assert await cb.allow()
+        await cb.record_failure()
+        assert not await cb.allow()
+        await asyncio.sleep(0.11)
+        assert await cb.allow()
+    asyncio.run(run())

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -23,7 +23,7 @@ class DummyPG(DummyDB):
 
 @pytest.fixture
 def client():
-    app = create_app(sql_db=DummyDB(), pg_db=DummyPG(), api_key="test")
+    app = create_app(sql_db=DummyDB(), pg_db=DummyPG(), api_key="test", rate_limit_per_sec=1)
     with TestClient(app) as client:
         yield client
 
@@ -62,3 +62,10 @@ def test_metrics_endpoint(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["claims_processed"] == 3
+
+
+def test_rate_limit(client):
+    resp1 = client.get("/liveness")
+    assert resp1.status_code == 200
+    resp2 = client.get("/liveness")
+    assert resp2.status_code == 429


### PR DESCRIPTION
## Summary
- implement a circuit breaker utility and integrate into Postgres and SQL Server clients
- add close methods to database classes and register FastAPI shutdown handler
- introduce simple token bucket rate limiter middleware
- test rate limiting and circuit breaker behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c666beed0832a9239c9abb03f9661