### PR TITLE
Add streaming and reliability features

### DIFF
--- a/src/processing/main.py
+++ b/src/processing/main.py
@@ -7,7 +7,7 @@ def main() -> None:
     cfg = load_config()
     pipeline = ClaimsPipeline(cfg)
     asyncio.run(pipeline.startup())
-    asyncio.run(pipeline.process_batch())
+    asyncio.run(pipeline.process_stream())
 
 
 if __name__ == "__main__":

--- a/src/utils/retries.py
+++ b/src/utils/retries.py
@@ -1,0 +1,29 @@
+import asyncio
+from functools import wraps
+from typing import Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def retry_async(retries: int = 3, backoff: float = 0.5,
+                exceptions: tuple[type[Exception], ...] = (Exception,)) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Retry an async function with exponential backoff."""
+
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> T:
+            delay = backoff
+            for attempt in range(retries):
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions:
+                    if attempt >= retries - 1:
+                        raise
+                    await asyncio.sleep(delay)
+                    delay *= 2
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+


### PR DESCRIPTION
## Summary
- add async retry helper
- extend ClaimService with streaming, checkpointing, dead-letter queue and priority fetch
- support dynamic batch sizing and stream processing in ClaimsPipeline
- run pipeline stream from main

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684c73e45648832a88fd4765a7c95ee6