### PR TITLE
Add operational tooling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,9 @@ priority queue for high‑value claims. Batch progress information is exposed fr
 the `/batch_status` endpoint, and `process_partial_claim` allows partial claim
 updates without reprocessing the full record.
 
+
+## Operations
+- See `migrations/README.md` for managing database migrations. Test migrations in a staging environment before production.
+- Monitoring setup is documented in [docs/MONITORING.md](docs/MONITORING.md).
+- Example alert rules are provided in [docs/ALERTING.md](docs/ALERTING.md).
+- Backup and restore instructions live in [docs/BACKUP_RESTORE.md](docs/BACKUP_RESTORE.md) with a helper script under `src/maintenance/backup_restore.py`.

--- a/docs/ALERTING.md
+++ b/docs/ALERTING.md
@@ -1,0 +1,17 @@
+# Alerting Rules
+
+Define alert thresholds for critical metrics to detect service degradation quickly.
+
+Example Prometheus alert rules:
+
+```
+- alert: HighErrorRate
+  expr: claims_failed / (claims_processed + 1) > 0.05
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: High claim failure rate detected
+```
+
+Configure alerts to notify on-call engineers via email or messaging channels when thresholds are exceeded.

--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -1,0 +1,15 @@
+# Backup and Restore Procedures
+
+Schedule periodic backups of the PostgreSQL and SQL Server databases. Backups can be performed with `pg_dump` and `sqlcmd` or `sqlpackage` depending on your environment.
+
+Example backup script:
+
+```bash
+python src/maintenance/backup_restore.py backup
+```
+
+Verify backups by performing a test restore periodically:
+
+```bash
+python src/maintenance/backup_restore.py restore path/to/backup.sql
+```

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,11 @@
+# Monitoring Setup
+
+The application exposes metrics from the `/metrics` endpoint of the FastAPI server. Export these metrics to Prometheus and visualize them with Grafana.
+
+## Key Metrics
+- `postgres_query_ms`: PostgreSQL query latency
+- `claims_processed`: number of successfully processed claims
+- `claims_failed`: number of failed claims
+- `postgres_pool_in_use`: connections used in the pool
+
+Create dashboards to track CPU, memory, error rates, and request latency. Review dashboards regularly to ensure they capture the desired insights.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -19,3 +19,5 @@ alembic upgrade head
 ```
 
 The configuration is provided in `alembic.ini` and migrations live under `migrations/versions`.
+
+Always test migrations in a staging environment before deploying to production. Use the `src/db/migrate.py` script to apply migrations from CI pipelines.

--- a/migrations/versions/0001_initial_schema.py
+++ b/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from alembic import op
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    sql_path = Path(__file__).resolve().parents[2] / 'sql' / 'create_postgres_schema.sql'
+    op.execute(sql_path.read_text())
+
+
+def downgrade():
+    op.execute('DROP SCHEMA public CASCADE; CREATE SCHEMA public;')

--- a/src/maintenance/backup_restore.py
+++ b/src/maintenance/backup_restore.py
@@ -1,0 +1,58 @@
+import asyncio
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from ..config.config import load_config
+
+
+async def backup() -> Path:
+    cfg = load_config()
+    outfile = Path(f"backup_{cfg.postgres.database}.sql")
+    subprocess.run(
+        [
+            "pg_dump",
+            f"--host={cfg.postgres.host}",
+            f"--port={cfg.postgres.port}",
+            f"--username={cfg.postgres.user}",
+            "-F",
+            "plain",
+            "-f",
+            str(outfile),
+            cfg.postgres.database,
+        ],
+        check=True,
+    )
+    return outfile
+
+
+async def restore(path: Path) -> None:
+    cfg = load_config()
+    subprocess.run(
+        [
+            "psql",
+            f"--host={cfg.postgres.host}",
+            f"--port={cfg.postgres.port}",
+            f"--username={cfg.postgres.user}",
+            cfg.postgres.database,
+            "-f",
+            str(path),
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: backup_restore.py [backup|restore <file>]")
+        raise SystemExit(1)
+    cmd = sys.argv[1]
+    if cmd == "backup":
+        asyncio.run(backup())
+    elif cmd == "restore" and len(sys.argv) >= 3:
+        asyncio.run(restore(Path(sys.argv[2])))
+    else:
+        print("Invalid arguments")
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- document monitoring metrics and example alert rules
- add database backup/restore helper
- provide initial Alembic migration
- mention ops docs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a565e38832a8a46149c2f69a620