### PR TITLE
Enhance model lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ startup.
 
 ## ML Model
 The processing pipeline loads a scikit-learn model using the path specified in the `model.path` setting of `config.yaml`. Train your own model or obtain the file from the maintainers and update the configuration with the correct location.
+Model version and optional A/B test paths can also be configured. Basic model performance metrics are tracked using the in-memory metrics registry.
 
 To generate a sample model for development, run:
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,9 @@ cache:
   warm_rvu_codes: []
 model:
   path: model.joblib
+  version: "1"
+  ab_test_path: null
+  ab_test_ratio: 0.5
 logging:
   level: INFO
   aggregator_host: null

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -22,6 +22,7 @@ class FastAPI:
         self.routes = {}
         self.startup_handlers = []
         self.middleware_handlers = []
+        self.exception_handlers = {}
 
     def on_event(self, name):
         def decorator(func):
@@ -42,5 +43,16 @@ class FastAPI:
             return func
         return decorator
 
+    def add_middleware(self, cls, **kwargs):
+        instance = cls(**kwargs)
+        self.middleware_handlers.append(instance.dispatch)
+
+    def exception_handler(self, exc_cls):
+        def decorator(func):
+            self.exception_handlers[exc_cls] = func
+            return func
+        return decorator
+
 __all__ = ["FastAPI", "HTMLResponse", "HTTPException", "Header", "Request"]
+
 

--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,3 +1,10 @@
 class HTMLResponse(str):
     pass
 
+
+class JSONResponse(dict):
+    def __init__(self, content: dict, status_code: int = 200, headers: dict | None = None) -> None:
+        super().__init__(content)
+        self.status_code = status_code
+        self.headers = headers or {}
+

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -76,6 +76,9 @@ class CacheConfig:
 @dataclass
 class ModelConfig:
     path: str = "model.joblib"
+    version: str = "1"
+    ab_test_path: Optional[str] = None
+    ab_test_ratio: float = 0.5
 
 
 @dataclass

--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -1,4 +1,7 @@
-import asyncpg
+try:
+    import asyncpg
+except Exception:  # pragma: no cover - allow missing dependency in tests
+    asyncpg = None
 from typing import Iterable, Any
 import time
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,29 @@
+"""Model utilities and wrappers."""
+
+__all__ = [
+    "FilterModel",
+    "extract_features",
+    "ABTestModel",
+    "ModelMonitor",
+    "ModelRegistry",
+]
+
+from importlib import import_module as _import_module
+
+_MODULE_MAP = {
+    "FilterModel": "filter_model",
+    "extract_features": "features",
+    "ABTestModel": "ab_test",
+    "ModelMonitor": "monitor",
+    "ModelRegistry": "registry",
+}
+
+
+def __getattr__(name):
+    module_name = _MODULE_MAP.get(name)
+    if module_name:
+        module = _import_module(f"{__name__}.{module_name}")
+        return getattr(module, name)
+    raise AttributeError(name)
+
+

--- a/src/models/ab_test.py
+++ b/src/models/ab_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import random
+from typing import Any, Dict, Protocol
+
+
+class _Predictor(Protocol):
+    def predict(self, claim: Dict[str, Any]) -> int:
+        ...
+
+
+class ABTestModel:
+    """Route predictions between two models based on a ratio."""
+
+    def __init__(self, model_a: _Predictor, model_b: _Predictor, ratio: float = 0.5):
+        if not 0.0 < ratio < 1.0:
+            raise ValueError("ratio must be between 0 and 1")
+        self.model_a = model_a
+        self.model_b = model_b
+        self.ratio = ratio
+
+    def predict(self, claim: Dict[str, Any]) -> int:
+        if random.random() < self.ratio:
+            return self.model_a.predict(claim)
+        return self.model_b.predict(claim)

--- a/src/models/features.py
+++ b/src/models/features.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def extract_features(claim: Dict[str, Any]) -> Dict[str, float]:
+    """Simple feature engineering for claim prediction."""
+    features: Dict[str, float] = {}
+    proc_code = claim.get("procedure_code") or ""
+    features["procedure_code_len"] = float(len(str(proc_code)))
+    financial_class = claim.get("financial_class") or ""
+    features["financial_class_id"] = float(abs(hash(financial_class)) % 1000)
+    features["has_diagnosis"] = 1.0 if claim.get("primary_diagnosis") else 0.0
+    return features

--- a/src/models/filter_model.py
+++ b/src/models/filter_model.py
@@ -1,12 +1,20 @@
 from typing import Any, Dict
-import joblib
+try:
+    import joblib
+except Exception:  # pragma: no cover - allow missing dependency in tests
+    joblib = None
+from .features import extract_features
 
 
 class FilterModel:
-    def __init__(self, path: str):
+    def __init__(self, path: str, version: str = "1"):
         self.path = path
+        self.version = version
+        if not joblib:
+            raise ImportError("joblib is required to load models")
         self.model = joblib.load(path)
 
-    def predict(self, features: Dict[str, Any]) -> int:
+    def predict(self, claim: Dict[str, Any]) -> int:
+        features = extract_features(claim)
         vector = [features[k] for k in sorted(features)]
         return int(self.model.predict([vector])[0])

--- a/src/models/monitor.py
+++ b/src/models/monitor.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import Any
+from ..monitoring.metrics import metrics
+
+
+class ModelMonitor:
+    """Record basic model performance metrics."""
+
+    def __init__(self, version: str):
+        self.version = version
+
+    def record_prediction(self, label: int) -> None:
+        metrics.inc(f"model_{self.version}_pred_{label}")
+        metrics.inc(f"model_{self.version}_total")

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from typing import Any, Dict, Optional
+
+
+class ModelRegistry:
+    """In-memory model registry with simple version resolution."""
+
+    def __init__(self) -> None:
+        self._models: Dict[str, str] = {}
+        self._active: Optional[str] = None
+
+    def register(self, version: str, path: str, active: bool = False) -> None:
+        self._models[version] = path
+        if active:
+            self._active = version
+
+    def get_path(self, version: Optional[str] = None) -> str:
+        ver = version or self._active
+        if not ver or ver not in self._models:
+            raise ValueError("model version not found")
+        return self._models[ver]

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,37 @@
+from src.models.features import extract_features
+from src.models.ab_test import ABTestModel
+from src.models.monitor import ModelMonitor
+from src.monitoring.metrics import metrics
+
+class DummyModel:
+    def __init__(self, value: int):
+        self.value = value
+
+    def predict(self, claim):
+        return self.value
+
+def test_extract_features():
+    claim = {"procedure_code": "ABC", "financial_class": "X", "primary_diagnosis": "D"}
+    feats = extract_features(claim)
+    assert feats["procedure_code_len"] == 3
+    assert feats["has_diagnosis"] == 1.0
+
+
+def test_ab_test_model(monkeypatch):
+    model_a = DummyModel(1)
+    model_b = DummyModel(2)
+    ab = ABTestModel(model_a, model_b, ratio=0.5)
+    monkeypatch.setattr('random.random', lambda: 0.4)
+    assert ab.predict({}) == 1
+    monkeypatch.setattr('random.random', lambda: 0.6)
+    assert ab.predict({}) == 2
+
+
+def test_model_monitor():
+    monitor = ModelMonitor("v1")
+    metrics.set("model_v1_pred_1", 0)
+    metrics.set("model_v1_total", 0)
+    monitor.record_prediction(1)
+    assert metrics.get("model_v1_pred_1") == 1
+    assert metrics.get("model_v1_total") == 1
+


### PR DESCRIPTION
## Summary
- implement simple feature engineering
- add A/B test wrapper, model monitor, and registry
- expose new model configuration options
- support optional middleware for tests
- document model versioning in README
- add tests for new model utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7c76b47c832a8dc8580de8344ff3