### PR TITLE
Add performance utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Run the pipeline benchmark script with:
 ```bash
 python benchmarks/benchmark_pipeline.py
 ```
+Additional load testing utilities are available in `benchmarks/load_runner.py`.
+See [docs/PERFORMANCE.md](docs/PERFORMANCE.md) for resource monitoring and query
+analytics instructions.
 
 ## Contributing
 Contributions are welcome! Please open an issue to discuss any changes. Ensure tests pass before submitting a pull request and follow PEP 8 style conventions.

--- a/benchmarks/load_runner.py
+++ b/benchmarks/load_runner.py
@@ -1,0 +1,88 @@
+import asyncio
+import time
+from typing import List
+
+from src.processing.pipeline import ClaimsPipeline
+from src.config.config import (
+    AppConfig,
+    PostgresConfig,
+    SQLServerConfig,
+    ProcessingConfig,
+    SecurityConfig,
+    CacheConfig,
+    ModelConfig,
+)
+from src.services.claim_service import ClaimService
+from src.rules.engine import RulesEngine
+from src.validation.validator import ClaimValidator
+
+
+class DummyPostgres:
+    async def fetch(self, query: str, *params):
+        return []
+
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        return len(list(params_seq))
+
+
+class DummySQL:
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def execute_many(self, query: str, params_seq):
+        return len(list(params_seq))
+
+
+class DummyModel:
+    def predict(self, claim):
+        return 1
+
+
+def create_pipeline() -> ClaimsPipeline:
+    cfg = AppConfig(
+        postgres=PostgresConfig("", 0, "", "", ""),
+        sqlserver=SQLServerConfig("", 0, "", "", ""),
+        processing=ProcessingConfig(batch_size=1),
+        security=SecurityConfig(api_key="k"),
+        cache=CacheConfig(),
+        model=ModelConfig(path="model.joblib"),
+    )
+    pipeline = ClaimsPipeline(cfg)
+    pipeline.pg = DummyPostgres()
+    pipeline.sql = DummySQL()
+    pipeline.model = DummyModel()
+    pipeline.rules_engine = RulesEngine([])
+    pipeline.validator = ClaimValidator({"F1"}, set())
+    pipeline.service = ClaimService(pipeline.pg, pipeline.sql)
+    return pipeline
+
+
+async def worker(pipeline: ClaimsPipeline, iterations: int) -> None:
+    claim = {
+        "claim_id": "1",
+        "patient_account_number": "111",
+        "facility_id": "F1",
+        "procedure_code": "P1",
+    }
+    for _ in range(iterations):
+        await pipeline.process_claim(claim)
+
+
+async def run(concurrency: int = 10, iterations: int = 100) -> float:
+    pipeline = create_pipeline()
+    tasks: List[asyncio.Task] = []
+    start = time.perf_counter()
+    for _ in range(concurrency):
+        tasks.append(asyncio.create_task(worker(pipeline, iterations)))
+    await asyncio.gather(*tasks)
+    return time.perf_counter() - start
+
+
+if __name__ == "__main__":
+    duration = asyncio.run(run())
+    print(
+        f"Processed {10 * 100} claims concurrently in {duration:.4f}s"
+    )

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,22 @@
+# Performance Analysis
+
+This project includes utilities for evaluating throughput and database efficiency.
+
+## Benchmark Suite
+- `benchmarks/benchmark_pipeline.py` runs a simple sequential benchmark of claim processing.
+- `benchmarks/load_test.py` executes multiple concurrent workers to simulate load.
+
+Run either script directly with Python to measure execution time.
+
+## Resource Monitoring
+`src/monitoring/resource_monitor.py` exposes helpers to track CPU and memory usage. Call
+`start()` at application startup to begin collecting metrics which are available from the
+`/metrics` endpoint.
+
+## Query Analytics
+`src/analysis/query_stats.py` summarizes average query latency using metrics gathered at
+runtime. Execute it after processing to view the summary:
+
+```bash
+python -m src.analysis.query_stats
+```

--- a/src/analysis/query_stats.py
+++ b/src/analysis/query_stats.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from typing import Dict
+from ..monitoring.metrics import metrics
+
+
+def summarize() -> Dict[str, float]:
+    data = metrics.as_dict()
+    pg_ms = data.get("postgres_query_ms", 0.0)
+    pg_count = data.get("postgres_query_count", 0.0)
+    sql_ms = data.get("sqlserver_query_ms", 0.0)
+    sql_count = data.get("sqlserver_query_count", 0.0)
+    summary = {}
+    if pg_count:
+        summary["postgres_avg_ms"] = pg_ms / pg_count
+    if sql_count:
+        summary["sqlserver_avg_ms"] = sql_ms / sql_count
+    return summary
+
+
+if __name__ == "__main__":
+    print(summarize())

--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -74,6 +74,7 @@ class PostgresDatabase(BaseDatabase):
                 rows = await conn.fetch(query, *params)
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("postgres_query_ms", duration)
+            metrics.inc("postgres_query_count")
             await self.circuit_breaker.record_success()
             result = [dict(row) for row in rows]
             self.query_cache.set(cache_key, result)
@@ -104,6 +105,7 @@ class PostgresDatabase(BaseDatabase):
                 result = await conn.execute(query, *params)
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("postgres_query_ms", duration)
+            metrics.inc("postgres_query_count")
             await self.circuit_breaker.record_success()
             return int(result.split(" ")[-1])
         except asyncpg.PostgresError:
@@ -131,6 +133,7 @@ class PostgresDatabase(BaseDatabase):
                 await conn.executemany(query, params_list)
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("postgres_query_ms", duration)
+            metrics.inc("postgres_query_count")
             await self.circuit_breaker.record_success()
         except asyncpg.PostgresError:
             await self.circuit_breaker.record_failure()

--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -91,6 +91,7 @@ class SQLServerDatabase(BaseDatabase):
             rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            metrics.inc("sqlserver_query_count")
             await self.circuit_breaker.record_success()
             return rows
         except pyodbc.Error:
@@ -122,6 +123,7 @@ class SQLServerDatabase(BaseDatabase):
             conn.commit()
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            metrics.inc("sqlserver_query_count")
             await self.circuit_breaker.record_success()
             return cursor.rowcount
         except pyodbc.Error:
@@ -159,6 +161,7 @@ class SQLServerDatabase(BaseDatabase):
             conn.commit()
             duration = (time.perf_counter() - start) * 1000
             metrics.inc("sqlserver_query_ms", duration)
+            metrics.inc("sqlserver_query_count")
             await self.circuit_breaker.record_success()
             return cursor.rowcount
         except pyodbc.Error:

--- a/src/monitoring/resource_monitor.py
+++ b/src/monitoring/resource_monitor.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import asyncio
+from typing import Optional
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
+
+from .metrics import metrics
+
+_task: Optional[asyncio.Task] = None
+
+
+async def _collect(interval: float) -> None:
+    while True:
+        if psutil:
+            metrics.set("cpu_usage_percent", float(psutil.cpu_percent()))
+            mem = psutil.virtual_memory().used / (1024 * 1024)
+            metrics.set("memory_usage_mb", float(mem))
+        await asyncio.sleep(interval)
+
+
+def start(interval: float = 1.0) -> None:
+    """Start background resource monitoring."""
+    global _task
+    if _task:
+        return
+    loop = asyncio.get_event_loop()
+    _task = loop.create_task(_collect(interval))
+
+
+def stop() -> None:
+    """Stop background resource monitoring."""
+    global _task
+    if _task:
+        _task.cancel()
+        _task = None


### PR DESCRIPTION
## Summary
- add resource monitoring module
- add query performance summary helper
- add concurrent load runner example
- document performance utilities
- track query counts in database layers

## Testing
- `pytest -q`
- `PYTHONPATH=. python benchmarks/benchmark_pipeline.py` *(fails: ModuleNotFoundError: No module named 'durable')*
- `PYTHONPATH=. python benchmarks/load_runner.py` *(fails: ModuleNotFoundError: No module named 'durable')*

------
https://chatgpt.com/codex/tasks/task_e_684c80f5b17c832ab6d56c5618ab964c