### PR TITLE
Add production readiness configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+*.pyo
+venv
+.env
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+    - name: Run tests
+      run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "src.processing.main"]

--- a/README.md
+++ b/README.md
@@ -139,3 +139,5 @@ updates without reprocessing the full record.
 - Deployment steps are covered in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 - Operational runbook tasks can be found in [docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md).
 - Common troubleshooting tips live in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
+- The project includes a `Dockerfile` and Kubernetes manifest under `k8s/` for containerized deployments.
+- Continuous integration runs via GitHub Actions defined in `.github/workflows/ci.yml`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -32,3 +32,14 @@ This document outlines the basic steps to deploy the claims processing service i
    ```
 
 For containerized deployments you can base your Docker image on the official Python image and copy the application code into it. Make sure the working directory contains the model file and configuration prior to starting the service.
+
+## Docker and Kubernetes
+A reference `Dockerfile` is provided at the project root. Build the image with:
+```bash
+docker build -t claims-processing:latest .
+```
+Run it locally using:
+```bash
+docker run -p 8000:8000 claims-processing:latest
+```
+For Kubernetes deployments see `docs/DOCKER_K8S.md` and apply the manifest in `k8s/deployment.yaml`.

--- a/docs/DOCKER_K8S.md
+++ b/docs/DOCKER_K8S.md
@@ -1,0 +1,20 @@
+# Container and Kubernetes Deployment
+
+This guide explains how to build a Docker image and deploy the service to Kubernetes.
+
+## Build Docker Image
+```bash
+docker build -t claims-processing:latest .
+```
+
+## Run Locally
+```bash
+docker run -p 8000:8000 claims-processing:latest
+```
+
+## Kubernetes
+Apply the deployment manifest in `k8s/deployment.yaml`:
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+This creates a Deployment and Service exposing the API on port 80.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claims-processing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: claims-processing
+  template:
+    metadata:
+      labels:
+        app: claims-processing
+    spec:
+      containers:
+      - name: app
+        image: claims-processing:latest
+        env:
+        - name: APP_ENV
+          value: production
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: claims-processing
+spec:
+  selector:
+    app: claims-processing
+  ports:
+  - port: 80
+    targetPort: 8000

--- a/migrations/versions/0002_add_indexes.py
+++ b/migrations/versions/0002_add_indexes.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from alembic import op
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sql_path = Path(__file__).resolve().parents[2] / 'sql' / 'create_indexes.sql'
+    op.execute(sql_path.read_text())
+
+
+def downgrade() -> None:
+    pass

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+# Stub durable.lang so tests run without the dependency
+sys.modules.setdefault("asyncpg", types.ModuleType("asyncpg"))
+sys.modules.setdefault("joblib", types.ModuleType("joblib"))
+durable_module = types.ModuleType("durable")
+durable_lang = types.ModuleType("lang")
+durable_lang.ruleset = lambda name: (lambda func: func)
+durable_lang.when_all = lambda cond: (lambda func: func)
+durable_lang.m = object()
+durable_lang.post = lambda name, data: None
+setattr(durable_module, "lang", durable_lang)
+sys.modules.setdefault("durable", durable_module)
+sys.modules.setdefault("durable.lang", durable_lang)
+
+from src.processing import main
+
+
+class DummyPipeline:
+    def __init__(self, cfg):
+        self.started = False
+        self.processed = False
+
+    async def startup(self):
+        self.started = True
+
+    async def process_stream(self):
+        self.processed = True
+
+
+def test_main_invokes_pipeline(monkeypatch):
+    called = DummyPipeline(None)
+    monkeypatch.setattr(main, "ClaimsPipeline", lambda cfg: called)
+    monkeypatch.setattr(main, "load_config", lambda: None)
+    main.main()
+    assert called.started
+    assert called.processed


### PR DESCRIPTION
## Summary
- add Dockerfile and Kubernetes deployment
- configure GitHub Actions CI workflow
- document container and k8s deployment
- update deployment guide and README
- add Alembic migration for indexes
- add integration test for CLI entry point

## Testing
- `pytest -q`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c94180e44832ab1c2a627a41469c9