### PR TITLE
Add analytics utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ priority queue for high‑value claims. Batch progress information is exposed fr
 the `/batch_status` endpoint, and `process_partial_claim` allows partial claim
 updates without reprocessing the full record.
 
+## Analytics
+Additional utilities are provided to understand failed claims and revenue impact.
+- `src/analysis/revenue.py` calculates potential revenue loss from failures.
+- `src/analysis/failure_patterns.py` aggregates and ranks failure reasons.
+- `src/analysis/failure_predictor.py` offers a lightweight predictor for claim
+  failure probability with a fallback when scikit-learn is unavailable.
+- `src/analysis/trending.py` tracks moving averages and simple trends for any
+  numeric metric.
+
 
 ## Operations
 - See `migrations/README.md` for managing database migrations. Test migrations in a staging environment before production.

--- a/src/analysis/failure_patterns.py
+++ b/src/analysis/failure_patterns.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, List, Tuple
+
+from ..db.sql_server import SQLServerDatabase
+
+
+async def failure_reason_counts(db: SQLServerDatabase) -> Dict[str, int]:
+    """Return counts of failure reasons."""
+    rows = await db.fetch("SELECT failure_reason FROM failed_claims")
+    counter: Counter[str] = Counter(row.get("failure_reason") for row in rows)
+    return dict(counter)
+
+
+async def top_failure_reasons(
+    db: SQLServerDatabase, limit: int = 5
+) -> List[Tuple[str, int]]:
+    """Return the most common failure reasons."""
+    counts = await failure_reason_counts(db)
+    return sorted(counts.items(), key=lambda x: x[1], reverse=True)[:limit]

--- a/src/analysis/failure_predictor.py
+++ b/src/analysis/failure_predictor.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..models.features import extract_features
+
+try:  # pragma: no cover - allow missing dependency in some environments
+    from sklearn.linear_model import LogisticRegression
+except Exception:  # pragma: no cover - allow missing dependency
+    LogisticRegression = None
+
+
+class FailurePredictor:
+    """Predict the probability of a claim failing."""
+
+    def __init__(self) -> None:
+        if LogisticRegression:
+            self.model: LogisticRegression | None = LogisticRegression()
+            self.stats: Dict[str, tuple[int, int]] | None = None
+        else:  # pragma: no cover - used when scikit-learn is unavailable
+            self.model = None
+            self.stats = {}
+
+    def train(self, claims: List[Dict[str, Any]], labels: List[int]) -> None:
+        """Train the predictor using historical claim outcomes."""
+        if self.model:
+            vectors = []
+            for claim in claims:
+                feats = extract_features(claim)
+                vectors.append([feats[k] for k in sorted(feats)])
+            self.model.fit(vectors, labels)
+        else:  # pragma: no cover - simple frequency-based training
+            for claim, label in zip(claims, labels):
+                key = claim.get("procedure_code") or "unknown"
+                total, pos = self.stats.get(key, (0, 0))  # type: ignore[assignment]
+                self.stats[key] = (total + 1, pos + label)
+
+    def predict_proba(self, claim: Dict[str, Any]) -> float:
+        """Return the probability that the claim will fail."""
+        if self.model:
+            feats = extract_features(claim)
+            vector = [feats[k] for k in sorted(feats)]
+            proba = self.model.predict_proba([vector])[0][1]
+            return float(proba)
+        series = self.stats.get(claim.get("procedure_code") or "unknown")  # type: ignore[assignment]
+        if not series:
+            return 0.0
+        total, pos = series
+        return pos / total if total else 0.0

--- a/src/analysis/revenue.py
+++ b/src/analysis/revenue.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..db.sql_server import SQLServerDatabase
+
+
+async def calculate_potential_revenue_loss(db: SQLServerDatabase) -> float:
+    """Return the total potential revenue loss from failed claims."""
+    rows = await db.fetch(
+        "SELECT SUM(potential_revenue_loss) AS total FROM failed_claims"
+    )
+    if rows and isinstance(rows[0], dict):
+        return float(rows[0].get("total") or 0.0)
+    return 0.0
+
+
+async def revenue_loss_by_category(db: SQLServerDatabase) -> Dict[str, float]:
+    """Return revenue loss aggregated by failure category."""
+    rows = await db.fetch(
+        "SELECT failure_category, SUM(potential_revenue_loss) AS total "
+        "FROM failed_claims GROUP BY failure_category"
+    )
+    result: Dict[str, float] = {}
+    for row in rows:
+        category = row.get("failure_category") or "unknown"
+        result[category] = float(row.get("total") or 0.0)
+    return result

--- a/src/analysis/trending.py
+++ b/src/analysis/trending.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict
+
+
+class TrendingTracker:
+    """Track metric values and provide simple trending analysis."""
+
+    def __init__(self, window: int = 10) -> None:
+        self.window = window
+        self._data: Dict[str, Deque[float]] = {}
+
+    def record(self, name: str, value: float) -> None:
+        series = self._data.setdefault(name, deque(maxlen=self.window))
+        series.append(value)
+
+    def moving_average(self, name: str) -> float:
+        series = self._data.get(name)
+        if not series:
+            return 0.0
+        return sum(series) / len(series)
+
+    def trend(self, name: str) -> float:
+        series = self._data.get(name)
+        if not series or len(series) < 2:
+            return 0.0
+        return series[-1] - series[0]

--- a/tests/test_failure_analysis.py
+++ b/tests/test_failure_analysis.py
@@ -1,0 +1,65 @@
+import pytest
+
+from src.analysis.revenue import calculate_potential_revenue_loss, revenue_loss_by_category
+from src.analysis.failure_patterns import failure_reason_counts, top_failure_reasons
+from src.analysis.failure_predictor import FailurePredictor
+from src.analysis.trending import TrendingTracker
+
+
+class DummySQL:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def fetch(self, query: str, *params):
+        return self.rows
+
+
+@pytest.mark.asyncio
+async def test_revenue_loss():
+    db = DummySQL([{"total": 100.0}])
+    total = await calculate_potential_revenue_loss(db)
+    assert total == 100.0
+
+
+@pytest.mark.asyncio
+async def test_revenue_loss_by_category():
+    db = DummySQL([
+        {"failure_category": "A", "total": 50},
+        {"failure_category": "B", "total": 30},
+    ])
+    result = await revenue_loss_by_category(db)
+    assert result["A"] == 50
+    assert result["B"] == 30
+
+
+@pytest.mark.asyncio
+async def test_failure_pattern_counts():
+    rows = [
+        {"failure_reason": "x"},
+        {"failure_reason": "y"},
+        {"failure_reason": "x"},
+    ]
+    db = DummySQL(rows)
+    counts = await failure_reason_counts(db)
+    assert counts["x"] == 2
+    assert counts["y"] == 1
+    top = await top_failure_reasons(db, limit=1)
+    assert top[0] == ("x", 2)
+
+
+def test_failure_predictor():
+    claims = [{"procedure_code": "A"}, {"procedure_code": "B"}]
+    labels = [1, 0]
+    predictor = FailurePredictor()
+    predictor.train(claims, labels)
+    prob = predictor.predict_proba({"procedure_code": "A"})
+    assert 0.0 <= prob <= 1.0
+
+
+def test_trending_tracker():
+    tracker = TrendingTracker(window=3)
+    tracker.record("x", 1)
+    tracker.record("x", 2)
+    tracker.record("x", 3)
+    assert tracker.moving_average("x") == 2
+    assert tracker.trend("x") == 2


### PR DESCRIPTION
## Summary
- implement revenue impact utilities and trending tracker
- add failure pattern analyzer and failure predictor
- document analytics utilities in README
- test the new analysis modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc765cb6c832ab455c2dac46bea86