### PR TITLE
Add model experimentation framework and versioning

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,7 +3,10 @@
 __all__ = [
     "FilterModel",
     "extract_features",
+    "FeaturePipeline",
+    "default_feature_pipeline",
     "ABTestModel",
+    "ABTestManager",
     "ModelMonitor",
     "ModelRegistry",
 ]
@@ -13,7 +16,10 @@ from importlib import import_module as _import_module
 _MODULE_MAP = {
     "FilterModel": "filter_model",
     "extract_features": "features",
+    "FeaturePipeline": "features",
+    "default_feature_pipeline": "features",
     "ABTestModel": "ab_test",
+    "ABTestManager": "ab_test",
     "ModelMonitor": "monitor",
     "ModelRegistry": "registry",
 }

--- a/src/models/features.py
+++ b/src/models/features.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Callable, Dict, List
 
 
 def extract_features(claim: Dict[str, Any]) -> Dict[str, float]:
@@ -11,3 +11,19 @@ def extract_features(claim: Dict[str, Any]) -> Dict[str, float]:
     features["financial_class_id"] = float(abs(hash(financial_class)) % 1000)
     features["has_diagnosis"] = 1.0 if claim.get("primary_diagnosis") else 0.0
     return features
+
+
+class FeaturePipeline:
+    """Composable feature engineering pipeline."""
+
+    def __init__(self, steps: List[Callable[[Dict[str, Any]], Dict[str, float]]]):
+        self.steps = steps
+
+    def run(self, claim: Dict[str, Any]) -> Dict[str, float]:
+        features: Dict[str, float] = {}
+        for step in self.steps:
+            features.update(step(claim))
+        return features
+
+
+default_feature_pipeline = FeaturePipeline([extract_features])

--- a/src/models/filter_model.py
+++ b/src/models/filter_model.py
@@ -3,18 +3,24 @@ try:
     import joblib
 except Exception:  # pragma: no cover - allow missing dependency in tests
     joblib = None
-from .features import extract_features
+from .features import FeaturePipeline, default_feature_pipeline, extract_features
 
 
 class FilterModel:
-    def __init__(self, path: str, version: str = "1"):
+    def __init__(
+        self,
+        path: str,
+        version: str = "1",
+        feature_pipeline: FeaturePipeline | None = None,
+    ):
         self.path = path
         self.version = version
+        self.feature_pipeline = feature_pipeline or default_feature_pipeline
         if not joblib:
             raise ImportError("joblib is required to load models")
         self.model = joblib.load(path)
 
     def predict(self, claim: Dict[str, Any]) -> int:
-        features = extract_features(claim)
+        features = self.feature_pipeline.run(claim)
         vector = [features[k] for k in sorted(features)]
         return int(self.model.predict([vector])[0])

--- a/src/models/monitor.py
+++ b/src/models/monitor.py
@@ -12,3 +12,14 @@ class ModelMonitor:
     def record_prediction(self, label: int) -> None:
         metrics.inc(f"model_{self.version}_pred_{label}")
         metrics.inc(f"model_{self.version}_total")
+
+    def record_result(self, predicted: int, actual: int) -> None:
+        """Record a prediction with ground truth for accuracy tracking."""
+        metrics.inc(f"model_{self.version}_pred_{predicted}")
+        metrics.inc(f"model_{self.version}_total")
+        if predicted == actual:
+            metrics.inc(f"model_{self.version}_correct")
+        total = metrics.get(f"model_{self.version}_total")
+        correct = metrics.get(f"model_{self.version}_correct")
+        if total:
+            metrics.set(f"model_{self.version}_accuracy", correct / total)

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -3,19 +3,38 @@ from typing import Any, Dict, Optional
 
 
 class ModelRegistry:
-    """In-memory model registry with simple version resolution."""
+    """In-memory model registry with version activation and rollback."""
 
     def __init__(self) -> None:
         self._models: Dict[str, str] = {}
-        self._active: Optional[str] = None
+        self._history: list[str] = []
 
     def register(self, version: str, path: str, active: bool = False) -> None:
+        """Register a model version. Optionally activate it."""
         self._models[version] = path
         if active:
-            self._active = version
+            self.activate(version)
+
+    def activate(self, version: str) -> None:
+        """Activate a registered model version."""
+        if version not in self._models:
+            raise ValueError("model version not found")
+        if self._history and self._history[-1] == version:
+            return
+        self._history.append(version)
+
+    def current_version(self) -> Optional[str]:
+        return self._history[-1] if self._history else None
 
     def get_path(self, version: Optional[str] = None) -> str:
-        ver = version or self._active
+        ver = version or self.current_version()
         if not ver or ver not in self._models:
             raise ValueError("model version not found")
         return self._models[ver]
+
+    def rollback(self) -> str:
+        """Rollback to the previous model version and return it."""
+        if len(self._history) < 2:
+            raise ValueError("no previous version to rollback to")
+        self._history.pop()
+        return self._history[-1]

--- a/tests/test_ab_versioning.py
+++ b/tests/test_ab_versioning.py
@@ -1,0 +1,48 @@
+from src.models.registry import ModelRegistry
+from src.models.features import FeaturePipeline, default_feature_pipeline
+from src.models.monitor import ModelMonitor
+from src.models.ab_test import ABTestManager
+from src.monitoring.metrics import metrics
+
+class DummyModel:
+    def __init__(self, value, version):
+        self.value = value
+        self.version = version
+    def predict(self, claim):
+        return self.value
+
+def test_model_registry_rollback():
+    reg = ModelRegistry()
+    reg.register("v1", "path1", active=True)
+    reg.register("v2", "path2", active=False)
+    reg.activate("v2")
+    assert reg.current_version() == "v2"
+    reg.rollback()
+    assert reg.current_version() == "v1"
+
+def test_feature_pipeline():
+    def extra_step(claim):
+        return {"x": 1.0}
+    pipe = FeaturePipeline([default_feature_pipeline.run, extra_step])
+    feats = pipe.run({"procedure_code": "A"})
+    assert "x" in feats and "procedure_code_len" in feats
+
+def test_model_performance_monitor():
+    monitor = ModelMonitor("v1")
+    metrics.set("model_v1_total", 0)
+    metrics.set("model_v1_correct", 0)
+    monitor.record_result(1, 1)
+    assert metrics.get("model_v1_accuracy") == 1.0
+
+def test_ab_test_manager(monkeypatch):
+    a = DummyModel(1, "a")
+    b = DummyModel(2, "b")
+    manager = ABTestManager(a, b, ratio=0.5)
+    metrics.set("ab_exposure_a", 0)
+    metrics.set("ab_exposure_b", 0)
+    monkeypatch.setattr('random.random', lambda: 0.3)
+    assert manager.predict({}) == 1
+    assert metrics.get("ab_exposure_a") == 1
+    monkeypatch.setattr('random.random', lambda: 0.8)
+    assert manager.predict({}) == 2
+    assert metrics.get("ab_exposure_b") == 1


### PR DESCRIPTION
## Summary
- add `ABTestManager` for tracking variant usage
- introduce `FeaturePipeline` and default pipeline
- extend `ModelMonitor` to track accuracy
- overhaul `ModelRegistry` with activation and rollback
- allow `FilterModel` to accept a feature pipeline
- export new objects in `src.models.__init__`
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccd64fb4c832aa4f2beb6a6ba1157