### PR TITLE
Improve failed claim handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ This project includes basic security features to protect sensitive claim data.
 The system now features a global exception handler for the FastAPI application.
 Errors are categorized and recorded in the `failure_category` field for easier
 analysis. Failed operations are routed to a dead letter queue with automatic
-reprocessing attempts. Database inserts employ compensation transactions to
-remove partially inserted records when an error occurs.
+reprocessing attempts. Failed claims enter a priority based retry queue where
+automated repair is attempted before re‑insertion. Manual review workflows can
+assign claims to users and record resolution actions. Resolution metrics are
+tracked via the `/metrics` endpoint. Database inserts employ compensation
+transactions to remove partially inserted records when an error occurs.
 
 ## Claim Processing Enhancements
 The system now supports claim amendments using the `amend_claim` method and a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,3 +15,8 @@ flowchart TD
 ```
 
 The FastAPI application exposes operational endpoints for monitoring and reviewing failed claims. Caching and connection pools improve throughput under load.
+
+Failed claims are first stored in the dead letter queue. On startup they are
+loaded into a priority retry queue which attempts automated repair before
+another insertion attempt. Claims that still fail can be assigned to a user for
+manual resolution and the outcome is tracked for metrics.

--- a/src/processing/repair.py
+++ b/src/processing/repair.py
@@ -1,5 +1,6 @@
 from typing import List
 
+
 class ClaimRepairSuggester:
     """Generate simple repair suggestions for failed claims."""
 
@@ -15,3 +16,20 @@ class ClaimRepairSuggester:
             suggestions.append("Correct service dates")
         return "; ".join(suggestions)
 
+    def auto_repair(self, claim: dict, errors: List[str]) -> dict:
+        """Attempt simple automatic repairs based on validation errors."""
+        fixed = dict(claim)
+        if "invalid_facility" in errors:
+            fixed["facility_id"] = fixed.get("facility_id") or "UNKNOWN"
+        if "invalid_financial_class" in errors:
+            fixed["financial_class"] = fixed.get("financial_class") or "UNKNOWN"
+        if "invalid_dob" in errors:
+            start = fixed.get("service_from_date") or fixed.get("service_to_date")
+            if start:
+                fixed["date_of_birth"] = start
+        if "invalid_service_dates" in errors:
+            start = fixed.get("service_from_date")
+            end = fixed.get("service_to_date")
+            if start and end and start > end:
+                fixed["service_to_date"] = start
+        return fixed

--- a/tests/test_retry_queue.py
+++ b/tests/test_retry_queue.py
@@ -1,0 +1,61 @@
+import pytest
+
+from src.monitoring.metrics import metrics
+from src.services.claim_service import ClaimService
+
+
+class DummySQL:
+    def __init__(self):
+        self.queries = []
+
+    async def execute(self, query: str, *params):
+        self.queries.append((query, params))
+        return 1
+
+    async def fetch(self, query: str, *params):
+        return []
+
+
+class DummyPG:
+    async def execute(self, query: str, *params):
+        return 1
+
+    async def fetch(self, query: str, *params):
+        return []
+
+
+async def noop(*args, **kwargs):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_retry_queue_priority(monkeypatch):
+    service = ClaimService(DummyPG(), DummySQL())
+    monkeypatch.setattr("src.utils.audit.record_audit_event", noop)
+    claim_low = {
+        "claim_id": "1",
+        "patient_account_number": "1",
+        "facility_id": "F1",
+        "priority": 1,
+    }
+    claim_hi = {
+        "claim_id": "2",
+        "patient_account_number": "2",
+        "facility_id": "F2",
+        "priority": 5,
+    }
+    await service.record_failed_claim(claim_low, "bad", "fix")
+    await service.record_failed_claim(claim_hi, "bad", "fix")
+    popped = service.retry_queue.pop()
+    assert popped["claim_id"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_manual_resolution(monkeypatch):
+    sql = DummySQL()
+    service = ClaimService(DummyPG(), sql)
+    monkeypatch.setattr("src.utils.audit.record_audit_event", noop)
+    await service.assign_failed_claim("x", "user1")
+    await service.resolve_failed_claim("x", "retry", "ok")
+    assert any("UPDATE failed_claims SET assigned_to" in q[0] for q in sql.queries)
+    assert metrics.get("failed_claims_manual") == 1


### PR DESCRIPTION
## Summary
- automate repair attempts for failed claims
- prioritize retry queue for failed claims
- add manual resolution workflow helpers
- document new retry behavior and manual review
- test retry queue and manual resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cce705fec832a9097d6774c067401