### PR TITLE
Fix duplicate query tracking

### DIFF
--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -80,8 +80,6 @@ class PostgresDatabase(BaseDatabase):
             metrics.inc("postgres_query_count")
             latencies.record("postgres_query", duration)
             record_query(query, duration)
-            record_query(query, duration)
-            record_query(query, duration)
             await self.circuit_breaker.record_success()
             result = [dict(row) for row in rows]
             self.query_cache.set(cache_key, result)

--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -107,8 +107,6 @@ class SQLServerDatabase(BaseDatabase):
             metrics.inc("sqlserver_query_count")
             latencies.record("sqlserver_query", duration)
             record_query(query, duration)
-            record_query(query, duration)
-            record_query(query, duration)
             await self.circuit_breaker.record_success()
             self.query_cache.set(cache_key, rows)
             return rows


### PR DESCRIPTION
## Summary
- remove redundant query recording in database fetches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd92ee1a0832abee92eee76846c53