### PR TITLE
Switch dead-letter deserialization to JSON

### DIFF
--- a/src/services/claim_service.py
+++ b/src/services/claim_service.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Iterable, List
+import json
 
 from ..db.postgres import PostgresDatabase
 from ..db.sql_server import SQLServerDatabase
@@ -160,7 +161,7 @@ class ClaimService:
                 except Exception:
                     continue
             try:
-                claim = eval(claim_str)
+                claim = json.loads(claim_str)
             except Exception:
                 continue
             pr = int(claim.get("priority", 0) or 0)


### PR DESCRIPTION
## Summary
- avoid `eval()` when reading failed claims
- parse claim data with `json.loads`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd939c484832abc459c6805a8f152