### PR TITLE
Implement cache pre-warming and checkpoint buffering

### DIFF
--- a/tests/test_checkpoint_buffer.py
+++ b/tests/test_checkpoint_buffer.py
@@ -1,0 +1,27 @@
+import asyncio
+import pytest
+from src.services.claim_service import ClaimService
+
+class DummyPG:
+    def __init__(self):
+        self.recorded = []
+
+    async def execute_many(self, query, params_seq, *, concurrency=1):
+        self.recorded.extend(list(params_seq))
+        return len(self.recorded)
+
+    async def execute(self, query, *params):
+        self.recorded.append(params)
+        return 1
+
+class DummySQL:
+    pass
+
+@pytest.mark.asyncio
+async def test_checkpoint_buffer_flushes():
+    pg = DummyPG()
+    service = ClaimService(pg, DummySQL(), checkpoint_buffer_size=5)
+    for i in range(7):
+        await service.record_checkpoint(str(i), "start")
+    await service.flush_checkpoints()
+    assert len(pg.recorded) == 7

--- a/tests/test_pipeline_stream.py
+++ b/tests/test_pipeline_stream.py
@@ -36,6 +36,9 @@ class DummyPostgres:
     async def connect(self):
         pass
 
+    async def execute_many(self, query, params_seq, concurrency=1):
+        return len(list(params_seq))
+
 
 class DummySQL:
     def __init__(self):


### PR DESCRIPTION
## Summary
- add batch checkpoint buffering to `ClaimService`
- fetch valid facilities and financial classes during startup
- warm RVU cache with top codes
- flush checkpoints at the end of batch and stream processing
- update tests for new warmup behaviour and checkpoint buffering
- add new test for checkpoint buffer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d59870c20832a99e6b6664491a0be