### PR TITLE
Implement sharded claims processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project builds a high-performance claims processing system with an integrat
 
 ### Scaling Enhancements
 - `ShardedDatabase` distributes writes across multiple PostgreSQL instances using a hash of the shard key.
+- `ShardedClaimsProcessor` splits incoming claims by facility and runs each shard's pipeline in parallel for higher throughput.
 - SQL Server queries now use a read-through cache to avoid repeated lookups.
 - Materialized views defined in `sql/materialized_views.sql` accelerate analytics queries.
 - A lightweight `ChangeDataCapture` poller streams row changes for real-time synchronization.

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -1,0 +1,4 @@
+from .pipeline import ClaimsPipeline
+from .sharded import ShardedClaimsProcessor
+
+__all__ = ["ClaimsPipeline", "ShardedClaimsProcessor"]

--- a/src/processing/sharded.py
+++ b/src/processing/sharded.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Dict, Iterable
+
+from .pipeline import ClaimsPipeline
+from ..config.config import AppConfig
+
+
+class ShardedClaimsProcessor:
+    """Manage multiple ClaimsPipeline instances for sharded processing."""
+
+    def __init__(self, shard_configs: Dict[int, AppConfig]) -> None:
+        self.shards: Dict[int, ClaimsPipeline] = {}
+        for shard_id, cfg in shard_configs.items():
+            self.shards[shard_id] = ClaimsPipeline(cfg)
+
+    def get_shard_id(self, facility_id: str | None) -> int:
+        """Return the shard id for a given facility."""
+        if facility_id is None:
+            return 0
+        return hash(facility_id) % len(self.shards)
+
+    async def process_claims_sharded(self, claims: Iterable[Dict[str, Any]]) -> None:
+        """Process claims by routing them to their facility shard."""
+        facility_groups: Dict[int, list[Dict[str, Any]]] = defaultdict(list)
+        for claim in claims:
+            facility_id = claim.get("facility_id")
+            shard_id = self.get_shard_id(facility_id)
+            facility_groups[shard_id].append(claim)
+
+        tasks = [
+            self.shards[shard_id].process_claims_batch(shard_claims)
+            for shard_id, shard_claims in facility_groups.items()
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)

--- a/tests/test_sharded_processor.py
+++ b/tests/test_sharded_processor.py
@@ -1,0 +1,49 @@
+import asyncio
+import types
+import sys
+
+sys.modules.setdefault("asyncpg", types.ModuleType("asyncpg"))
+
+from src.processing.sharded import ShardedClaimsProcessor
+
+
+class DummyPipeline:
+    def __init__(self, cfg):
+        self.batches = []
+
+    async def process_claims_batch(self, claims):
+        self.batches.append(list(claims))
+
+
+def test_process_claims_sharded(monkeypatch):
+    # Replace ClaimsPipeline with DummyPipeline
+    monkeypatch.setattr(
+        "src.processing.sharded.ClaimsPipeline", lambda cfg: DummyPipeline(cfg)
+    )
+    configs = {0: object(), 1: object()}
+    proc = ShardedClaimsProcessor(configs)
+
+    # Map facilities deterministically
+    def shard_for_facility(self, facility_id):
+        return 0 if facility_id == "A" else 1
+
+    monkeypatch.setattr(
+        ShardedClaimsProcessor, "get_shard_id", shard_for_facility, raising=False
+    )
+
+    claims = [
+        {"facility_id": "A", "claim_id": "1"},
+        {"facility_id": "B", "claim_id": "2"},
+        {"facility_id": "A", "claim_id": "3"},
+    ]
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(proc.process_claims_sharded(claims))
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+    assert proc.shards[0].batches == [[{"facility_id": "A", "claim_id": "1"}, {"facility_id": "A", "claim_id": "3"}]]
+    assert proc.shards[1].batches == [[{"facility_id": "B", "claim_id": "2"}]]


### PR DESCRIPTION
## Summary
- introduce `ShardedClaimsProcessor` for facility based claim sharding
- export the new processor from `src.processing`
- document shard processing in README
- add unit test for `ShardedClaimsProcessor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6572cab0832a835eddae6d2f4e6b