### PR TITLE
Add system resource logging

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,6 +89,7 @@ concurrency:
 monitoring:
   enable_system_monitoring: true
   resource_check_interval: 5  # seconds
+  resource_log_interval: 60  # seconds
   performance_history_size: 200
   
   # Alerting thresholds

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -90,6 +90,7 @@ class MonitoringConfig:
     """Resource monitoring configuration."""
     enable_system_monitoring: bool = True
     resource_check_interval: int = 5
+    resource_log_interval: int = 60
     performance_history_size: int = 200
     alerts: AlertConfig = field(default_factory=AlertConfig)
 
@@ -291,6 +292,7 @@ def _create_monitoring_config(data: Dict[str, Any]) -> MonitoringConfig:
     return MonitoringConfig(
         enable_system_monitoring=monitoring_data.get("enable_system_monitoring", True),
         resource_check_interval=monitoring_data.get("resource_check_interval", 5),
+        resource_log_interval=monitoring_data.get("resource_log_interval", 60),
         performance_history_size=monitoring_data.get("performance_history_size", 200),
         alerts=alerts
     )
@@ -562,6 +564,7 @@ def save_config(cfg: AppConfig, path: str = "config.yaml") -> None:
         "monitoring": {
             "enable_system_monitoring": cfg.monitoring.enable_system_monitoring,
             "resource_check_interval": cfg.monitoring.resource_check_interval,
+            "resource_log_interval": cfg.monitoring.resource_log_interval,
             "performance_history_size": cfg.monitoring.performance_history_size,
             "alerts": {
                 "high_cpu_threshold": cfg.monitoring.alerts.high_cpu_threshold,

--- a/src/processing/pipeline.py
+++ b/src/processing/pipeline.py
@@ -505,7 +505,10 @@ class ClaimsPipeline:
         monitoring_start = time.perf_counter()
         
         # Start resource monitoring
-        resource_monitor.start(interval=0.5)  # More frequent monitoring
+        resource_monitor.start(
+            interval=self.cfg.monitoring.resource_check_interval,
+            log_interval=self.cfg.monitoring.resource_log_interval,
+        )
         pool_monitor.start(self.pg, self.sql, interval=2.0)
         
         # Start memory monitoring


### PR DESCRIPTION
## Summary
- log CPU and memory usage via `resource_monitor`
- configure logging interval via `monitoring.resource_log_interval`
- pass interval settings when starting `resource_monitor`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684db254f608832a81a39c946a46d32c