### PR TITLE
Add dependency health checks

### DIFF
--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -37,6 +37,8 @@ class TestClient:
         if headers and "X-User-Role" in headers:
             kwargs["x_user_role"] = headers["X-User-Role"]
         request = Request(headers)
+        request.url = type("URL", (), {"path": path})()
+        request.method = "GET"
         if "request" in func.__code__.co_varnames:
             kwargs["request"] = request
         try:

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -151,6 +151,12 @@ class DistributedCache:
         except Exception:
             self.client = None
 
+    async def health_check(self) -> bool:
+        """Public wrapper for Redis connection health check."""
+        if not self.client:
+            return False
+        return await self._health_check()
+
     async def get(self, key: str) -> Optional[Any]:
         """Get item from distributed cache with connection health check."""
         if not self.client:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from src.web.app import create_app
+from src.config.config import create_default_config
 
 class DummyDB:
     async def connect(self):
@@ -19,9 +20,20 @@ class DummyDB:
 class DummyPG(DummyDB):
     pass
 
+
+class DummyRedis:
+    async def health_check(self):
+        return True
+
 @pytest.fixture
 def client():
-    app = create_app(sql_db=DummyDB(), pg_db=DummyPG(), api_key="test")
+    app = create_app(
+        sql_db=DummyDB(),
+        pg_db=DummyPG(),
+        redis_cache=DummyRedis(),
+        cfg=create_default_config(),
+        api_key="test",
+    )
     with TestClient(app) as client:
         yield client
 


### PR DESCRIPTION
## Summary
- add public `health_check` to `DistributedCache`
- allow external services and Redis in `create_app`
- report redis and external service status in health endpoints
- make request logging middleware robust for tests
- extend TestClient to populate request path/method
- update tests for new health checks

## Testing
- `pytest tests/test_web.py tests/test_tracing.py -q`
- `pytest -q` *(fails: `test_pipeline_batch_performance` and others)*

------
https://chatgpt.com/codex/tasks/task_e_684ded66eee8832a85de327e105bf0a2