### PR TITLE
Add Kubernetes health probes

### DIFF
--- a/docs/DOCKER_K8S.md
+++ b/docs/DOCKER_K8S.md
@@ -18,3 +18,7 @@ Apply the deployment manifest in `k8s/deployment.yaml`:
 kubectl apply -f k8s/deployment.yaml
 ```
 This creates a Deployment and Service exposing the API on port 80.
+
+The Deployment also configures liveness and readiness probes. Kubernetes
+checks `/liveness` and `/readiness` on port `8000` to ensure the service is
+running correctly.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,6 +20,18 @@ spec:
           value: production
         ports:
         - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- define readiness and liveness probes in the deployment manifest
- document the health probes in the Docker/K8s guide

## Testing
- `pytest -q` *(fails: DummyPostgres errors)*
- `pip install pre-commit` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_684def6c1844832aa315fad9dd474e7c