### PR TITLE
Remove cryptography fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a high-level system diagram
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+# The cryptography package is required for encryption support.
+# It is included in the requirements file but must be installed for the
+# application to start correctly.
 pip install pre-commit
 pre-commit install
 ```

--- a/docs/HIPAA_COMPLIANCE.md
+++ b/docs/HIPAA_COMPLIANCE.md
@@ -9,6 +9,8 @@ This project processes Protected Health Information (PHI). The following checkli
 
 ## Technical Safeguards
 - Encrypt PHI at rest and in transit using the `encryption_key` from `config.yaml`.
+- The application requires the `cryptography` package to be installed for these
+  encryption features.
 - Ensure user authentication for all web endpoints via API key and role headers.
 - Record access events in the `audit_log` table for traceability.
 

--- a/src/security/compliance.py
+++ b/src/security/compliance.py
@@ -1,17 +1,12 @@
 from typing import Dict, Any
-try:  # pragma: no cover - cryptography may be unavailable
+
+try:
     from cryptography.fernet import Fernet
-except Exception:  # pragma: no cover - simple fallback cipher
-
-    class Fernet:  # type: ignore
-        def __init__(self, key: bytes):
-            self.key = key
-
-        def encrypt(self, text: bytes) -> bytes:
-            return text[::-1]
-
-        def decrypt(self, token: bytes) -> bytes:
-            return token[::-1]
+except Exception as exc:  # pragma: no cover - enforce dependency
+    raise ImportError(
+        "The 'cryptography' package is required for encryption features. "
+        "Install it with 'pip install cryptography'."
+    ) from exc
 
 
 def _get_cipher(key: str) -> Fernet:

--- a/tests/test_encryption_error.py
+++ b/tests/test_encryption_error.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_missing_cryptography_raises(monkeypatch):
+    monkeypatch.dict(sys.modules, {"cryptography": None})
+    sys.modules.pop("src.security.compliance", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("src.security.compliance")
+    # reload module for other tests
+    importlib.import_module("src.security.compliance")


### PR DESCRIPTION
## Summary
- require `cryptography` for encryption support
- document new dependency requirement
- mention `cryptography` in HIPAA compliance docs
- add test verifying missing cryptography triggers ImportError

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_684dfe737dfc832a89a15b289265f810