### PR TITLE
Add encrypted backup/restore

### DIFF
--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -2,6 +2,9 @@
 
 Schedule periodic backups of the PostgreSQL and SQL Server databases. Backups can be performed with `pg_dump` and `sqlcmd` or `sqlpackage` depending on your environment.
 
+Backups are encrypted using GnuPG with the `security.encryption_key` from
+`config.yaml`.  The backup file is written with a `.sql.gpg` extension.
+
 Example backup script:
 
 ```bash
@@ -11,5 +14,7 @@ python src/maintenance/backup_restore.py backup
 Verify backups by performing a test restore periodically:
 
 ```bash
-python src/maintenance/backup_restore.py restore path/to/backup.sql
+python src/maintenance/backup_restore.py restore path/to/backup.sql.gpg
 ```
+
+The same encryption key must be present in `config.yaml` when restoring.

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,48 @@
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from src.maintenance import backup_restore
+
+
+@pytest.mark.asyncio
+async def test_backup_restore_encrypted(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.sql"
+    data_file.write_text("SELECT 1;\n")
+
+    cfg = SimpleNamespace(
+        postgres=SimpleNamespace(host="localhost", port=5432, user="u", database="db"),
+        security=SimpleNamespace(encryption_key="testkey"),
+    )
+    monkeypatch.setattr(backup_restore, "load_config", lambda: cfg)
+
+    real_popen = subprocess.Popen
+
+    def fake_popen(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "pg_dump":
+            return real_popen(["cat", str(data_file)], stdout=subprocess.PIPE)
+        return real_popen(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    captured = tmp_path / "restored.sql"
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd and cmd[0] == "psql":
+            stdin = kwargs.get("stdin")
+            if stdin:
+                with open(captured, "wb") as f:
+                    f.write(stdin.read())
+                return subprocess.CompletedProcess(cmd, 0)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    backup_file = await backup_restore.backup()
+    assert backup_file.exists()
+
+    await backup_restore.restore(backup_file)
+
+    assert captured.read_text() == "SELECT 1;\n"


### PR DESCRIPTION
## Summary
- encrypt backups using gpg and decrypt on restore
- document encrypted backup usage
- stub cryptography and monkeypatch helpers for tests
- add test covering encrypted backup and restore

## Testing
- `pytest tests/test_backup_restore.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography.fernet')*

------
https://chatgpt.com/codex/tasks/task_e_684e001e86ec832a9d6ed6c07dd0bbf1