### PR TITLE
Add identifier validation for ChangeDataCapture

### DIFF
--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.db.cdc import ChangeDataCapture
+
+
+class DummyDB:
+    async def fetch(self, *args, **kwargs):
+        return []
+
+
+def test_invalid_table_name():
+    with pytest.raises(ValueError):
+        ChangeDataCapture(DummyDB(), "claims;")
+
+
+def test_invalid_id_column():
+    with pytest.raises(ValueError):
+        ChangeDataCapture(DummyDB(), "claims", id_column="id;")
+


### PR DESCRIPTION
## Summary
- validate identifiers for ChangeDataCapture
- test validation of table and column names

## Testing
- `pre-commit run --files src/db/cdc.py tests/test_cdc.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: no internet access)*
- `pytest -q tests/test_cdc.py`

------
https://chatgpt.com/codex/tasks/task_e_684e021b4464832a880c4b924e98e153