### PR TITLE
Encrypt archived claim records

### DIFF
--- a/docs/DATA_MANAGEMENT.md
+++ b/docs/DATA_MANAGEMENT.md
@@ -14,14 +14,14 @@ python -m src.maintenance.partition_historical_data
 
 ### Archival Process
 1. A nightly maintenance job runs `python -m src.maintenance.archive_old_claims`.
-2. Claims where `service_to_date` is more than 36 months old are exported to encrypted JSON Lines files under `archive/YYYY/MM/`.
+2. Claims where `service_to_date` is more than 36 months old are exported to encrypted JSON Lines files under `archive/YYYY/MM/`. Each record is first processed with `encrypt_claim_fields` and then the entire JSON string is encrypted with `encrypt_text`.
 3. After export, the archived rows are deleted from the live tables in a single transaction.
 4. The archived files are uploaded to cold storage (for example, an S3 bucket or on‑prem object store).
 
 The encryption key used for the archive is the same `encryption_key` from `config.yaml`.
 
 ### Restoration
-To restore data from an archive file, decrypt it and load the records back into the database using a script such as `restore_archived_claims.py`.
+Each line in the archive must be decrypted with `decrypt_text` using the same `encryption_key`. The resulting JSON contains field‑level encrypted values which should be decrypted again before insertion. See the `restore_archived_claims.py` helper for a full example.
 
 ## Automated Retention Policy
 The `enforce_retention_policy.py` helper under `src/maintenance` can be scheduled via cron to automatically archive claims older than 36 months and purge archive files beyond the seven‑year retention window.

--- a/src/maintenance/archive_old_claims.py
+++ b/src/maintenance/archive_old_claims.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from ..config.config import load_config
 from ..db.postgres import PostgresDatabase
+from ..security.compliance import encrypt_claim_fields, encrypt_text
 
 ARCHIVE_PATH = os.getenv("ARCHIVE_PATH", "archive")
 
@@ -20,8 +21,15 @@ async def archive_old_claims(days: int = 1095) -> None:
         os.makedirs(ARCHIVE_PATH, exist_ok=True)
         fname = os.path.join(ARCHIVE_PATH, f"claims_{cutoff:%Y_%m_%d}.jsonl")
         with open(fname, "w", encoding="utf-8") as f:
+            key = cfg.security.encryption_key
             for row in rows:
-                f.write(json.dumps(row, default=str) + "\n")
+                record = dict(row)
+                if key:
+                    record = encrypt_claim_fields(record, key)
+                    line = encrypt_text(json.dumps(record, default=str), key)
+                else:
+                    line = json.dumps(record, default=str)
+                f.write(line + "\n")
         await db.execute("DELETE FROM claims WHERE service_to_date < $1", cutoff)
     await db.close()
 


### PR DESCRIPTION
## Summary
- encrypt sensitive claim data when archiving
- document how each archive line is encrypted and how to restore
- test that archived files store encrypted values

## Testing
- `pytest tests/test_encryption.py::test_encrypt_decrypt_roundtrip tests/test_encryption.py::test_encrypt_claim_fields -q`
- `pytest tests/test_archive.py::test_archive_with_rows -q`

------
https://chatgpt.com/codex/tasks/task_e_684e02ee3388832aac909ac2105f696e