### PR TITLE
Implement jitter and max delay in retry_async

### DIFF
--- a/src/utils/retries.py
+++ b/src/utils/retries.py
@@ -1,13 +1,34 @@
 import asyncio
+import random
 from functools import wraps
 from typing import Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 
 
-def retry_async(retries: int = 3, backoff: float = 0.5,
-                exceptions: tuple[type[Exception], ...] = (Exception,)) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
-    """Retry an async function with exponential backoff."""
+def retry_async(
+    retries: int = 3,
+    backoff: float = 0.5,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+    *,
+    max_delay: float | None = None,
+    jitter: float = 0.0,
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Retry an async function with exponential backoff.
+
+    Parameters
+    ----------
+    retries:
+        Number of attempts before giving up.
+    backoff:
+        Initial delay between retries.
+    exceptions:
+        Exception types to catch and retry.
+    max_delay:
+        Maximum delay between attempts. ``None`` for unlimited.
+    jitter:
+        Apply random jitter in the range ``± jitter * delay``.
+    """
 
     def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
         @wraps(func)
@@ -19,8 +40,15 @@ def retry_async(retries: int = 3, backoff: float = 0.5,
                 except exceptions:
                     if attempt >= retries - 1:
                         raise
-                    await asyncio.sleep(delay)
+                    sleep_time = delay
+                    if jitter:
+                        jitter_range = jitter * sleep_time
+                        sleep_time += random.uniform(-jitter_range, jitter_range)
+                        sleep_time = max(0.0, sleep_time)
+                    await asyncio.sleep(sleep_time)
                     delay *= 2
+                    if max_delay is not None:
+                        delay = min(delay, max_delay)
             return await func(*args, **kwargs)
 
         return wrapper

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,47 @@
+import asyncio
+import random
+import pytest
+
+from src.utils.retries import retry_async
+
+
+def test_retry_async_jitter_and_max_delay(monkeypatch):
+    calls = 0
+    delays: list[float] = []
+
+    async def failing():
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise ValueError("fail")
+        return calls
+
+    async def fake_sleep(delay: float):
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    random.seed(1)
+    wrapped = retry_async(retries=3, backoff=1.0, max_delay=2.5, jitter=0.1)(failing)
+
+    result = asyncio.run(wrapped())
+
+    assert result == 3
+    assert abs(delays[0] - 0.9268728488224803) < 1e-6
+    assert abs(delays[1] - 2.138973494774893) < 1e-6
+
+
+def test_retry_async_respects_max_delay(monkeypatch):
+    delays: list[float] = []
+
+    async def always_fail():
+        raise RuntimeError
+
+    async def fake_sleep(delay: float):
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    with pytest.raises(RuntimeError):
+        wrapped = retry_async(retries=3, backoff=1.0, max_delay=2.0)(always_fail)
+        asyncio.run(wrapped())
+
+    assert delays == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- extend `retry_async` decorator with `max_delay` and `jitter` options
- record jittered exponential backoff and max delay behaviour in new unit tests

## Testing
- `pytest -q tests/test_retries.py`
- `pytest -q` *(fails: test suite errors)*
- `pre-commit run --files src/utils/retries.py tests/test_retries.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0ed85454832aa66c6601395d086e