### PR TITLE
Add configurable connection retry backoff

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -109,6 +109,10 @@ class PostgresConfig:
     min_pool_size: int = 25
     max_pool_size: int = 150
     threshold_ms: int = 1000
+    retries: int = 3
+    retry_delay: float = 0.5
+    retry_max_delay: float | None = None
+    retry_jitter: float = 0.0
 
 
 @dataclass
@@ -123,6 +127,10 @@ class SQLServerConfig:
     min_pool_size: int = 25
     max_pool_size: int = 80
     threshold_ms: int = 1000
+    retries: int = 3
+    retry_delay: float = 0.5
+    retry_max_delay: float | None = None
+    retry_jitter: float = 0.0
 
 
 @dataclass
@@ -465,14 +473,22 @@ def create_default_config() -> AppConfig:
             port=5432,
             user="claims_user",
             password="password",
-            database="staging_process"
+            database="staging_process",
+            retries=3,
+            retry_delay=0.5,
+            retry_max_delay=None,
+            retry_jitter=0.0
         ),
         sqlserver=SQLServerConfig(
             host="localhost",
             port=1433,
             user="claims_user",
             password="password",
-            database="smart_pro_claims"
+            database="smart_pro_claims",
+            retries=3,
+            retry_delay=0.5,
+            retry_max_delay=None,
+            retry_jitter=0.0
         ),
         processing=ProcessingConfig(),
         security=SecurityConfig(
@@ -502,7 +518,11 @@ def save_config(cfg: AppConfig, path: str = "config.yaml") -> None:
             "replica_port": cfg.postgres.replica_port,
             "min_pool_size": cfg.postgres.min_pool_size,
             "max_pool_size": cfg.postgres.max_pool_size,
-            "threshold_ms": cfg.postgres.threshold_ms
+            "threshold_ms": cfg.postgres.threshold_ms,
+            "retries": cfg.postgres.retries,
+            "retry_delay": cfg.postgres.retry_delay,
+            "retry_max_delay": cfg.postgres.retry_max_delay,
+            "retry_jitter": cfg.postgres.retry_jitter
         },
         "sqlserver": {
             "host": cfg.sqlserver.host,
@@ -513,7 +533,11 @@ def save_config(cfg: AppConfig, path: str = "config.yaml") -> None:
             "pool_size": cfg.sqlserver.pool_size,
             "min_pool_size": cfg.sqlserver.min_pool_size,
             "max_pool_size": cfg.sqlserver.max_pool_size,
-            "threshold_ms": cfg.sqlserver.threshold_ms
+            "threshold_ms": cfg.sqlserver.threshold_ms,
+            "retries": cfg.sqlserver.retries,
+            "retry_delay": cfg.sqlserver.retry_delay,
+            "retry_max_delay": cfg.sqlserver.retry_max_delay,
+            "retry_jitter": cfg.sqlserver.retry_jitter
         },
         "processing": {
             "batch_size": cfg.processing.batch_size,

--- a/src/db/postgres.py
+++ b/src/db/postgres.py
@@ -236,6 +236,10 @@ class PostgresDatabase(BaseDatabase):
             self.circuit_breaker,
             CircuitBreakerOpenError("Postgres circuit open"),
             _open,
+            retries=self.cfg.retries,
+            delay=self.cfg.retry_delay,
+            max_delay=self.cfg.retry_max_delay,
+            jitter=self.cfg.retry_jitter,
         )
 
     async def fetch_optimized_with_memory_management(

--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -163,6 +163,10 @@ class SQLServerDatabase(BaseDatabase):
             self.circuit_breaker,
             CircuitBreakerOpenError("SQLServer circuit open"),
             _open,
+            retries=self.cfg.retries,
+            delay=self.cfg.retry_delay,
+            max_delay=self.cfg.retry_max_delay,
+            jitter=self.cfg.retry_jitter,
         )
 
     def _create_connection_optimized(self) -> pyodbc.Connection:

--- a/tests/test_connection_utils.py
+++ b/tests/test_connection_utils.py
@@ -1,0 +1,77 @@
+import asyncio
+import random
+import pytest
+
+from src.db.connection_utils import connect_with_retry
+from src.utils.errors import CircuitBreakerOpenError, DatabaseConnectionError
+
+
+class DummyCB:
+    async def allow(self):
+        return True
+
+    async def record_success(self):
+        pass
+
+    async def record_failure(self):
+        pass
+
+
+def test_connect_with_retry_jitter_and_max_delay(monkeypatch):
+    calls = 0
+    delays = []
+
+    async def failing():
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise ValueError("fail")
+        return calls
+
+    async def fake_sleep(delay: float):
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    random.seed(1)
+    cb = DummyCB()
+    result = asyncio.run(
+        connect_with_retry(
+            cb,
+            CircuitBreakerOpenError("open"),
+            failing,
+            retries=3,
+            delay=1.0,
+            max_delay=2.5,
+            jitter=0.1,
+        )
+    )
+
+    assert result == 3
+    assert abs(delays[0] - 0.9268728488224803) < 1e-6
+    assert abs(delays[1] - 2.138973494774893) < 1e-6
+
+
+def test_connect_with_retry_respects_max_delay(monkeypatch):
+    delays = []
+
+    async def always_fail():
+        raise RuntimeError
+
+    async def fake_sleep(delay: float):
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    cb = DummyCB()
+    with pytest.raises(DatabaseConnectionError):
+        asyncio.run(
+            connect_with_retry(
+                cb,
+                CircuitBreakerOpenError("open"),
+                always_fail,
+                retries=3,
+                delay=1.0,
+                max_delay=2.0,
+            )
+        )
+
+    assert delays == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- add exponential backoff with jitter to `connect_with_retry`
- extend `PostgresConfig` and `SQLServerConfig` with retry fields
- pass retry parameters from DB config
- expose retry fields in default config and save_config
- test jitter and max delay logic for connection retry

## Testing
- `pytest -q tests/test_connection_utils.py tests/test_retries.py`

------
https://chatgpt.com/codex/tasks/task_e_684e0fddb988832a8474c19e3f5f9633