### PR TITLE
Add security scanning and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest
+        pip install bandit
     - name: Run tests
       run: pytest -q
+    - name: Security scan
+      run: bandit -r src -ll

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ operational monitoring. The `/compliance/dashboard` route summarizes
 audit events and data retention status. Full API documentation is available at
 `/docs` when the server is running. The raw OpenAPI specification can be
 downloaded from `/openapi.json`.
+Additional endpoint details are summarized in
+[docs/API_DOCUMENTATION.md](docs/API_DOCUMENTATION.md).
 
 ## Tests
 Tests use `pytest`.
@@ -180,5 +182,6 @@ Additional utilities are provided to understand failed claims and revenue impact
 - Deployment steps are covered in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 - Operational runbook tasks can be found in [docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md).
 - Common troubleshooting tips live in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
+- Change management guidelines are documented in [docs/CHANGE_MANAGEMENT.md](docs/CHANGE_MANAGEMENT.md).
 - The project includes a `Dockerfile` and Kubernetes manifest under `k8s/` for containerized deployments.
 - Continuous integration runs via GitHub Actions defined in `.github/workflows/ci.yml`.

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1,22 +1,32 @@
 # API Documentation
 
-The FastAPI application automatically generates an OpenAPI specification and interactive Swagger UI.
+The FastAPI service exposes a REST API secured with API key authentication.
+Interactive documentation is available when the service is running.
 
-- **Swagger UI**: visit `http://<host>:8000/docs` while the service is running to explore the endpoints and schemas.
-- **OpenAPI JSON**: the raw specification is available at `http://<host>:8000/openapi.json`.
+- **Swagger UI**: `http://<host>:8000/docs`
+- **OpenAPI JSON**: `http://<host>:8000/openapi.json`
 
-The main API endpoints include:
-- `/failed_claims` – view recently failed claims.
-- `/status` – processing statistics for the current run.
-- `/batch_status` – details about the active batch.
-- `/health` and `/readiness` – service health checks.
-- `/compliance/dashboard` – summary of audit logs and retention status.
+## Endpoints
 
-Authentication requires an API key in the `X-API-Key` header. Example request using `curl`:
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/failed_claims` | HTML view of the most recent claim failures |
+| `GET` | `/api/failed_claims` | JSON list of failed claims |
+| `GET` | `/status` | Processing statistics for the current run |
+| `GET` | `/batch_status` | Detailed batch information |
+| `GET` | `/health` | Health status of downstream services |
+| `GET` | `/readiness` | Readiness probe for Kubernetes |
+| `GET` | `/liveness` | Simple liveness probe |
+| `GET` | `/metrics` | Prometheus formatted metrics |
+| `GET` | `/profiling/start` | Begin CPU profiling |
+| `GET` | `/profiling/stop` | Stop profiling and return stats |
+| `GET` | `/compliance/dashboard` | Summary of audit logs and archival status |
+
+### Example Request
+
 ```bash
 curl -H "X-API-Key: <key>" http://<host>:8000/status
 ```
 
-### Compliance Dashboard Screenshot
+Responses are JSON encoded except for the `/failed_claims` HTML page.
 
-![Compliance Dashboard](images/compliance_dashboard.png)

--- a/docs/CHANGE_MANAGEMENT.md
+++ b/docs/CHANGE_MANAGEMENT.md
@@ -1,0 +1,19 @@
+# Change Management Procedures
+
+This document outlines the procedures for introducing changes to the claims processing system.
+
+## Proposal
+- Create a short design proposal for significant changes.
+- Document potential impacts and rollback steps.
+
+## Review and Approval
+- Submit code via pull request and request at least one reviewer.
+- Ensure tests and security scans pass before merging.
+
+## Deployment
+- Use the deployment checklist in [docs/DEPLOYMENT.md](DEPLOYMENT.md).
+- Record configuration or schema modifications in `migrations/README.md`.
+
+## Rollback
+- Tag releases so that previous versions can be redeployed quickly.
+- Maintain database backups for point‑in‑time recovery.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -19,3 +19,11 @@ This runbook describes routine tasks for keeping the claims processing system he
   systemctl restart claims-worker
   ```
 - For persistent database issues, switch to the standby instance and update `config.yaml` accordingly.
+
+## Monthly Tasks
+- Review change management log for completed deployments.
+- Rotate encryption keys if required by policy.
+
+## Incident Response
+- Declare an incident in the monitoring system and page on-call staff.
+- Document the resolution steps in the incident tracker.

--- a/docs/SECURITY_SCANNING.md
+++ b/docs/SECURITY_SCANNING.md
@@ -8,3 +8,6 @@ bandit -r src -ll
 ```
 
 Running the command as part of CI or a pre‑commit hook ensures security issues are caught before deployment.
+
+Our GitHub Actions workflow installs `bandit` and scans the `src` directory on every pull request.
+Failures will block the merge until issues are resolved.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -20,3 +20,11 @@ This guide lists common operational issues and their resolutions.
 - Confirm the FastAPI service is running.
 - Look for error messages in the application logs.
 - Check that rate limiting or API key restrictions are not blocking requests.
+
+## Failed Deployment
+- Review the CI logs for test or security scan failures.
+- Ensure Kubernetes manifests reference the correct image tag.
+
+## Data Synchronization Issues
+- Verify scheduled jobs that move data between staging and production.
+- Check replication lag metrics on the database servers.


### PR DESCRIPTION
## Summary
- run bandit security scans in CI
- expand API documentation
- expand troubleshooting guide and operations runbook
- document change management procedures
- mention docs in README

## Testing
- `pytest -q` *(fails: UnboundLocalError)*

------
https://chatgpt.com/codex/tasks/task_e_684e18ef3e54832aa6d5245641501caf