### PR TITLE
Add React frontend for failed claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ downloaded from `/openapi.json`.
 Additional endpoint details are summarized in
 [docs/API_DOCUMENTATION.md](docs/API_DOCUMENTATION.md).
 
+## Frontend
+The `ui/` directory contains a small React application used to view failed
+claims. To run it in development mode:
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+This starts the Vite dev server on <http://localhost:5173> and proxies API
+requests to the FastAPI backend running on port 8000. Build a production bundle
+with:
+
+```bash
+npm run build
+```
+
+Static files will be emitted to `ui/dist/`.
+
 ## Tests
 Tests use `pytest`.
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Claims UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "claims-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useMemo } from 'react';
+
+export default function App() {
+  const [claims, setClaims] = useState([]);
+  const [filter, setFilter] = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: 'failed_at', direction: 'desc' });
+
+  useEffect(() => {
+    fetch('/api/failed_claims', { headers: { 'X-API-Key': 'test' } })
+      .then((res) => res.json())
+      .then((data) => setClaims(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const sortedClaims = useMemo(() => {
+    return [...claims].sort((a, b) => {
+      if (a[sortConfig.key] < b[sortConfig.key]) return sortConfig.direction === 'asc' ? -1 : 1;
+      if (a[sortConfig.key] > b[sortConfig.key]) return sortConfig.direction === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [claims, sortConfig]);
+
+  const displayedClaims = useMemo(() => {
+    const lower = filter.toLowerCase();
+    return sortedClaims.filter((c) =>
+      Object.values(c).some((v) => String(v).toLowerCase().includes(lower))
+    );
+  }, [sortedClaims, filter]);
+
+  const requestSort = (key) => {
+    let direction = 'asc';
+    if (sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const getSortIndicator = (key) => {
+    if (sortConfig.key !== key) return '';
+    return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Failed Claims</h1>
+      <input
+        placeholder="Filter..."
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        style={{ marginBottom: '1rem' }}
+      />
+      <table border="1" cellPadding="5" cellSpacing="0">
+        <thead>
+          <tr>
+            <th onClick={() => requestSort('claim_id')}>Claim ID{getSortIndicator('claim_id')}</th>
+            <th onClick={() => requestSort('failure_reason')}>Reason{getSortIndicator('failure_reason')}</th>
+            <th onClick={() => requestSort('failed_at')}>Failed At{getSortIndicator('failed_at')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayedClaims.map((c) => (
+            <tr key={c.claim_id}>
+              <td>{c.claim_id}</td>
+              <td>{c.failure_reason}</td>
+              <td>{c.failed_at}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,6 @@
+body {
+  font-family: Arial, sans-serif;
+}
+th {
+  cursor: pointer;
+}

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold React UI under `ui/` using Vite
- create page to show `/api/failed_claims` in a sortable, filterable table
- document how to run the frontend

## Testing
- `pytest -q` *(fails: PytestUnhandledCoroutineWarning and several assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_684e1df48d64832a838e9e58079e57cb