### PR TITLE
Add compliance analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,15 @@ uvicorn src.web.app:app --reload
 The `/failed_claims` page lists recent failed claims and the `/status` endpoint
 returns processing counts so you can display a real-time indicator in the UI.
 Database and query metrics are exposed from the `/metrics` endpoint for
-operational monitoring. The `/compliance/dashboard` route summarizes
-audit events and data retention status. Full API documentation is available at
+operational monitoring. The `/compliance/dashboard` route now returns
+audit events, archive status, failure pattern data, processing trends and
+revenue impact metrics. Full API documentation is available at
 `/docs` when the server is running. The raw OpenAPI specification can be
 downloaded from `/openapi.json`.
 Additional endpoint details are summarized in
 [docs/API_DOCUMENTATION.md](docs/API_DOCUMENTATION.md).
+See [docs/DASHBOARD_USAGE.md](docs/DASHBOARD_USAGE.md) for information on the
+interactive dashboard.
 
 ## Frontend
 The `ui/` directory contains a small React application used to view failed

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -20,7 +20,7 @@ Interactive documentation is available when the service is running.
 | `GET` | `/metrics` | Prometheus formatted metrics |
 | `GET` | `/profiling/start` | Begin CPU profiling |
 | `GET` | `/profiling/stop` | Stop profiling and return stats |
-| `GET` | `/compliance/dashboard` | Summary of audit logs and archival status |
+| `GET` | `/compliance/dashboard` | Compliance metrics including audit counts, archive status, failure patterns, processing trends, and revenue impact |
 
 ### Example Request
 

--- a/docs/DASHBOARD_USAGE.md
+++ b/docs/DASHBOARD_USAGE.md
@@ -1,0 +1,12 @@
+# Compliance Dashboard Usage
+
+The React dashboard is served from the `/dashboard` path of the UI build. It visualises
+information returned by the `/compliance/dashboard` API endpoint.
+
+## Charts
+
+- **Failure Patterns** – bar chart of the top failure reasons.
+- **Processing Trends** – line chart of processed and failed claims over the last 30 days.
+- **Revenue Impact** – pie chart showing potential revenue loss grouped by failure category.
+
+Start the UI locally with `npm run dev` in the `ui/` directory and visit `http://localhost:5173/dashboard`.

--- a/tests/test_compliance_dashboard.py
+++ b/tests/test_compliance_dashboard.py
@@ -14,6 +14,8 @@ class DummyDB:
     async def fetch(self, query: str, *params):
         if "audit_log" in query:
             return [{"count": 5}]
+        if "daily_processing_summary" in query:
+            return []
         return []
 
     async def execute(self, query: str, *params):
@@ -59,3 +61,6 @@ def test_dashboard_endpoint(dashboard_client):
     data = resp.json()
     assert data["total_audit_events"] == 5
     assert data["archive_files"] == 1
+    assert "failure_patterns" in data
+    assert "processing_trends" in data
+    assert "revenue_impact" in data

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,72 +1,11 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React from 'react';
+import FailedClaims from './FailedClaims';
+import Dashboard from './Dashboard';
 
 export default function App() {
-  const [claims, setClaims] = useState([]);
-  const [filter, setFilter] = useState('');
-  const [sortConfig, setSortConfig] = useState({ key: 'failed_at', direction: 'desc' });
-
-  useEffect(() => {
-    fetch('/api/failed_claims', { headers: { 'X-API-Key': 'test' } })
-      .then((res) => res.json())
-      .then((data) => setClaims(data))
-      .catch((err) => console.error(err));
-  }, []);
-
-  const sortedClaims = useMemo(() => {
-    return [...claims].sort((a, b) => {
-      if (a[sortConfig.key] < b[sortConfig.key]) return sortConfig.direction === 'asc' ? -1 : 1;
-      if (a[sortConfig.key] > b[sortConfig.key]) return sortConfig.direction === 'asc' ? 1 : -1;
-      return 0;
-    });
-  }, [claims, sortConfig]);
-
-  const displayedClaims = useMemo(() => {
-    const lower = filter.toLowerCase();
-    return sortedClaims.filter((c) =>
-      Object.values(c).some((v) => String(v).toLowerCase().includes(lower))
-    );
-  }, [sortedClaims, filter]);
-
-  const requestSort = (key) => {
-    let direction = 'asc';
-    if (sortConfig.key === key && sortConfig.direction === 'asc') {
-      direction = 'desc';
-    }
-    setSortConfig({ key, direction });
-  };
-
-  const getSortIndicator = (key) => {
-    if (sortConfig.key !== key) return '';
-    return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
-  };
-
-  return (
-    <div style={{ padding: '1rem' }}>
-      <h1>Failed Claims</h1>
-      <input
-        placeholder="Filter..."
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        style={{ marginBottom: '1rem' }}
-      />
-      <table border="1" cellPadding="5" cellSpacing="0">
-        <thead>
-          <tr>
-            <th onClick={() => requestSort('claim_id')}>Claim ID{getSortIndicator('claim_id')}</th>
-            <th onClick={() => requestSort('failure_reason')}>Reason{getSortIndicator('failure_reason')}</th>
-            <th onClick={() => requestSort('failed_at')}>Failed At{getSortIndicator('failed_at')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {displayedClaims.map((c) => (
-            <tr key={c.claim_id}>
-              <td>{c.claim_id}</td>
-              <td>{c.failure_reason}</td>
-              <td>{c.failed_at}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+  const path = window.location.pathname;
+  if (path.startsWith('/dashboard')) {
+    return <Dashboard />;
+  }
+  return <FailedClaims />;
 }

--- a/ui/src/Dashboard.jsx
+++ b/ui/src/Dashboard.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line, Pie } from 'react-chartjs-2';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend
+);
+
+export default function Dashboard() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/compliance/dashboard', { headers: { 'X-API-Key': 'test' } })
+      .then((res) => res.json())
+      .then((d) => setData(d))
+      .catch((err) => console.error(err));
+  }, []);
+
+  if (!data) return <div>Loading...</div>;
+
+  const failureLabels = data.failure_patterns.map((f) => f[0]);
+  const failureCounts = data.failure_patterns.map((f) => f[1]);
+
+  const trendLabels = data.processing_trends.map((t) => t.date);
+  const processed = data.processing_trends.map((t) => t.processed);
+  const failed = data.processing_trends.map((t) => t.failed);
+
+  const catLabels = Object.keys(data.revenue_impact.by_category);
+  const catValues = Object.values(data.revenue_impact.by_category);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Compliance Dashboard</h1>
+      <h2>Failure Patterns</h2>
+      <Bar
+        data={{
+          labels: failureLabels,
+          datasets: [
+            {
+              label: 'Failures',
+              data: failureCounts,
+              backgroundColor: 'rgba(255,99,132,0.5)',
+            },
+          ],
+        }}
+      />
+      <h2>Processing Trends (30d)</h2>
+      <Line
+        data={{
+          labels: trendLabels,
+          datasets: [
+            {
+              label: 'Processed',
+              data: processed,
+              borderColor: 'green',
+            },
+            {
+              label: 'Failed',
+              data: failed,
+              borderColor: 'red',
+            },
+          ],
+        }}
+      />
+      <h2>Revenue Impact</h2>
+      <Pie
+        data={{
+          labels: catLabels,
+          datasets: [
+            {
+              data: catValues,
+              backgroundColor: [
+                '#ff6384',
+                '#36a2eb',
+                '#ffcd56',
+                '#4bc0c0',
+                '#9966ff',
+              ],
+            },
+          ],
+        }}
+      />
+      <p>Total Potential Revenue Loss: ${data.revenue_impact.total.toFixed(2)}</p>
+    </div>
+  );
+}

--- a/ui/src/FailedClaims.jsx
+++ b/ui/src/FailedClaims.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useMemo } from 'react';
+
+export default function FailedClaims() {
+  const [claims, setClaims] = useState([]);
+  const [filter, setFilter] = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: 'failed_at', direction: 'desc' });
+
+  useEffect(() => {
+    fetch('/api/failed_claims', { headers: { 'X-API-Key': 'test' } })
+      .then((res) => res.json())
+      .then((data) => setClaims(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const sortedClaims = useMemo(() => {
+    return [...claims].sort((a, b) => {
+      if (a[sortConfig.key] < b[sortConfig.key]) return sortConfig.direction === 'asc' ? -1 : 1;
+      if (a[sortConfig.key] > b[sortConfig.key]) return sortConfig.direction === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [claims, sortConfig]);
+
+  const displayedClaims = useMemo(() => {
+    const lower = filter.toLowerCase();
+    return sortedClaims.filter((c) =>
+      Object.values(c).some((v) => String(v).toLowerCase().includes(lower))
+    );
+  }, [sortedClaims, filter]);
+
+  const requestSort = (key) => {
+    let direction = 'asc';
+    if (sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const getSortIndicator = (key) => {
+    if (sortConfig.key !== key) return '';
+    return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Failed Claims</h1>
+      <input
+        placeholder="Filter..."
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        style={{ marginBottom: '1rem' }}
+      />
+      <table border="1" cellPadding="5" cellSpacing="0">
+        <thead>
+          <tr>
+            <th onClick={() => requestSort('claim_id')}>Claim ID{getSortIndicator('claim_id')}</th>
+            <th onClick={() => requestSort('failure_reason')}>Reason{getSortIndicator('failure_reason')}</th>
+            <th onClick={() => requestSort('failed_at')}>Failed At{getSortIndicator('failed_at')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayedClaims.map((c) => (
+            <tr key={c.claim_id}>
+              <td>{c.claim_id}</td>
+              <td>{c.failure_reason}</td>
+              <td>{c.failed_at}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `/compliance/dashboard` with failure pattern, processing trend and revenue data
- add new React charts for the dashboard
- document the additional API fields and provide dashboard usage guide

## Testing
- `pytest tests/test_compliance_dashboard.py -q`
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ea03350832a95bcdc632d6d40b2