### PR TITLE
Add FK for facilities.region_id

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -89,6 +89,13 @@ CREATE TABLE facilities (
 );
 GO
 
+ALTER TABLE facilities
+    ADD CONSTRAINT fk_facility_region FOREIGN KEY (region_id)
+        REFERENCES facility_region(region_id);
+
+CREATE INDEX idx_facilities_region_id ON facilities (region_id);
+GO
+
 CREATE TABLE facility_financial_classes (
     facility_id INT,
     financial_class_id VARCHAR(10),


### PR DESCRIPTION
## Summary
- add `fk_facility_region` foreign key after `CREATE TABLE facilities`
- add supporting index `idx_facilities_region_id`

## Testing
- `pre-commit run --files sql/create_sqlserver_schema.sql` *(fails: command not found)*
- `pytest -k "" -q` *(fails: coroutine object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_684e20561738832aa4654ff26b9821a6