### PR TITLE
Add index on audit log table

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -21,6 +21,9 @@ CREATE TABLE audit_log (
     approved_at DATETIME2(7) NULL
 );
 GO
+CREATE INDEX idx_audit_log_record ON audit_log(record_id, operation_timestamp);
+-- Consider including table_name in a composite index if queries often
+-- filter by table
 
 CREATE TABLE daily_processing_summary (
     summary_date DATE NOT NULL,


### PR DESCRIPTION
## Summary
- add an index on `audit_log` in SQL Server schema
- document that `table_name` can be included in a composite index

## Testing
- `pytest -q` *(fails: AttributeError: 'DummySQL' object has no attribute 'fetch', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e23b435d8832abb6c3bd95c473c53