### PR TITLE
Add claim resolution UI and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Additional endpoint details are summarized in
 [docs/API_DOCUMENTATION.md](docs/API_DOCUMENTATION.md).
 See [docs/DASHBOARD_USAGE.md](docs/DASHBOARD_USAGE.md) for information on the
 interactive dashboard.
+The API also exposes `/api/assign_failed_claim` and `/api/resolve_failed_claim`
+for managing failed claims. A minimal UI is available at `/resolve`.
 
 ## Frontend
 The `ui/` directory contains a small React application used to view failed

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -21,6 +21,8 @@ Interactive documentation is available when the service is running.
 | `GET` | `/profiling/start` | Begin CPU profiling |
 | `GET` | `/profiling/stop` | Stop profiling and return stats |
 | `GET` | `/compliance/dashboard` | Compliance metrics including audit counts, archive status, failure patterns, processing trends, and revenue impact |
+| `POST` | `/api/assign_failed_claim` | Assign a failed claim to a user |
+| `POST` | `/api/resolve_failed_claim` | Mark a failed claim as resolved |
 
 ### Example Request
 

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -37,6 +37,12 @@ class FastAPI:
             return func
         return decorator
 
+    def post(self, path, response_class=None):
+        def decorator(func):
+            self.routes[("POST", path)] = func
+            return func
+        return decorator
+
     def middleware(self, _):
         def decorator(func):
             self.middleware_handlers.append(func)

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -65,3 +65,39 @@ class TestClient:
 
         return response
 
+    def post(self, path, json=None, headers=None):
+        func = self.app.routes.get(("POST", path))
+        if not func:
+            return Response(status_code=404, content="Not Found")
+        kwargs = json or {}
+        if headers and "X-API-Key" in headers:
+            kwargs["x_api_key"] = headers["X-API-Key"]
+        if headers and "X-User-Role" in headers:
+            kwargs["x_user_role"] = headers["X-User-Role"]
+        request = Request(headers)
+        request.url = type("URL", (), {"path": path})()
+        request.method = "POST"
+        if "request" in func.__code__.co_varnames:
+            kwargs["request"] = request
+        try:
+            if asyncio.iscoroutinefunction(func):
+                result = self.loop.run_until_complete(func(**kwargs))
+            else:
+                result = func(**kwargs)
+        except HTTPException as exc:
+            result = Response(status_code=exc.status_code, json={"detail": exc.detail})
+        if isinstance(result, Response):
+            response = result
+        else:
+            response = Response(json=result, headers={})
+
+        async def call_next(_):
+            return response
+
+        for mw in reversed(self.app.middleware_handlers):
+            response = self.loop.run_until_complete(mw(request, call_next))
+            async def call_next(_):
+                return response
+
+        return response
+

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import FailedClaims from './FailedClaims';
 import Dashboard from './Dashboard';
+import ClaimResolution from './ClaimResolution';
 
 export default function App() {
   const path = window.location.pathname;
   if (path.startsWith('/dashboard')) {
     return <Dashboard />;
+  }
+  if (path.startsWith('/resolve')) {
+    return <ClaimResolution />;
   }
   return <FailedClaims />;
 }

--- a/ui/src/ClaimResolution.jsx
+++ b/ui/src/ClaimResolution.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ClaimResolution() {
+  const [claims, setClaims] = useState([]);
+  const [user, setUser] = useState('');
+
+  useEffect(() => {
+    fetch('/api/failed_claims', { headers: { 'X-API-Key': 'test' } })
+      .then((res) => res.json())
+      .then((data) => setClaims(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const assignClaim = (id) => {
+    fetch('/api/assign_failed_claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': 'test' },
+      body: JSON.stringify({ claim_id: id, user }),
+    }).then(() => alert('Assigned'));
+  };
+
+  const resolveClaim = (id) => {
+    const action = prompt('Resolution action?');
+    if (!action) return;
+    const notes = prompt('Notes?') || '';
+    fetch('/api/resolve_failed_claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': 'test' },
+      body: JSON.stringify({ claim_id: id, action, notes }),
+    }).then(() => setClaims((prev) => prev.filter((c) => c.claim_id !== id)));
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Resolve Failed Claims</h1>
+      <input
+        placeholder="User..."
+        value={user}
+        onChange={(e) => setUser(e.target.value)}
+        style={{ marginBottom: '1rem' }}
+      />
+      <table border="1" cellPadding="5" cellSpacing="0">
+        <thead>
+          <tr>
+            <th>Claim ID</th>
+            <th>Reason</th>
+            <th>Failed At</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {claims.map((c) => (
+            <tr key={c.claim_id}>
+              <td>{c.claim_id}</td>
+              <td>{c.failure_reason}</td>
+              <td>{c.failed_at}</td>
+              <td>
+                <button onClick={() => assignClaim(c.claim_id)}>Assign</button>
+                <button onClick={() => resolveClaim(c.claim_id)}>Resolve</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expand FastAPI stub to handle POST requests
- expose `/api/assign_failed_claim` and `/api/resolve_failed_claim`
- add corresponding tests
- implement simple React page `/resolve` for assigning and resolving claims
- document new endpoints and UI

## Testing
- `pre-commit run --files README.md docs/API_DOCUMENTATION.md src/web/app.py tests/test_web.py ui/src/App.jsx ui/src/ClaimResolution.jsx` *(fails: command not found)*
- `pytest tests/test_web.py::test_assign_failed_claim tests/test_web.py::test_resolve_failed_claim -q`
- `pytest -q` *(fails: 6 failed, 96 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684e24683ab8832a8cffb1c8752c847e