### PR TITLE
Add Faker dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a high-level system diagram
 ## Requirements
 - Python 3.10 or newer
 - Recommended: create a virtual environment
+- Faker is required for the sample data generator and installs with the
+  requirements.
 
 ```bash
 # Create virtual environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ cryptography==41.0.3
 redis==5.0.0
 alembic==1.12.0
 sentry-sdk==1.43.0
+faker>=25.0.0
 
 # Database & Performance
 sqlalchemy>=2.0.0


### PR DESCRIPTION
## Summary
- add `faker>=25.0.0` to core dependencies
- document Faker in the requirements section of the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684ec82a03f4832a8d1760ff7b3c735b