### PR TITLE
Fix PostgresDatabase import path

### DIFF
--- a/scripts/README_sample_data.md
+++ b/scripts/README_sample_data.md
@@ -139,7 +139,7 @@ python -m src.processing.main
 
 # Check processing results
 python -c "
-from src.database.postgres import PostgresDatabase
+from src.db.postgres import PostgresDatabase
 from src.config.config import load_config
 import asyncio
 

--- a/scripts/generate_sample_data.py
+++ b/scripts/generate_sample_data.py
@@ -17,7 +17,7 @@ import asyncpg
 from faker import Faker
 
 from src.config.config import load_config
-from src.database.postgres import PostgresDatabase
+from src.db.postgres import PostgresDatabase
 
 # Initialize Faker for realistic data generation
 fake = Faker()


### PR DESCRIPTION
## Summary
- use `src.db.postgres.PostgresDatabase` in sample data generator
- update README snippet accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684ecd80edb0832a89d2f4e8f4ebbd9b