### PR TITLE
Fix setup_dev.sh virtualenv activation

### DIFF
--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -2,10 +2,10 @@
 # Setup development environment
 set -e
 python -m venv venv
-venv\Scripts\activate
+source venv/bin/activate
 pip install uv
 uv pip install -r requirements.txt
 pip install pre-commit
 pre-commit install
 
-echo "Development environment is ready. Activate it with 'source venv\Scripts\activate'."
+echo "Development environment is ready. Activate it with 'source venv/bin/activate'."


### PR DESCRIPTION
## Summary
- use POSIX virtual environment activation path in `scripts/setup_dev.sh`

## Testing
- `pytest -q` *(fails: Interrupted with errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0acf138832aaac5ab7344f04ae1