### PR TITLE
Wrap sample data processing options as JSON

### DIFF
--- a/scripts/generate_sample_data.py
+++ b/scripts/generate_sample_data.py
@@ -467,14 +467,14 @@ async def create_batch_metadata(db: PostgresDatabase, total_claims: int) -> str:
             batch_id, submitted_by, submitted_at, total_claims,
             status, priority, processing_options
         ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-    """,
+        """,
         batch_id,
         "data_generator",
         datetime.now(),
         total_claims,
         "completed",
         "normal",
-        {"generated": True, "source": "sample_data_generator"},
+        asyncpg.types.Json({"generated": True, "source": "sample_data_generator"}),
     )
 
     return batch_id


### PR DESCRIPTION
## Summary
- wrap processing_options in `create_batch_metadata` with `asyncpg.types.Json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684edd7dab20832a8fc8750e84a2f5b2