### PR TITLE
Add primary key to facility_coders table

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -169,7 +169,7 @@ GO
 
 CREATE TABLE facility_coders (
     facility_id INT,
-    coder_id VARCHAR(50),
+    coder_id VARCHAR(50) PRIMARY KEY,
     coder_last_name VARCHAR(50),
     coder_first_name VARCHAR(50)
 );


### PR DESCRIPTION
## Summary
- add a primary key on `coder_id` for the `facility_coders` table in the SQL Server schema

## Testing
- `pytest -q` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684ee043ceac832a8a36c463aac7af84