### PR TITLE
Fix SQL Server schema FKs and parsing

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -629,8 +629,11 @@ class DatabaseSetupOrchestrator:
         """
 
         if sql_server:
-            # SQL Server uses GO as batch separator
-            raw_statements = sql_content.split("GO")
+            # SQL Server uses GO as batch separator. Split on lines that
+            # contain only GO, ignoring case and surrounding whitespace.
+            raw_statements = re.split(
+                r"^\s*GO\s*$", sql_content, flags=re.IGNORECASE | re.MULTILINE
+            )
         else:
             raw_statements = []
             current = []

--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -105,7 +105,7 @@ CREATE INDEX idx_facilities_region_id ON facilities (region_id);
 GO
 
 CREATE TABLE core_standard_payers (
-    payer_id INT,
+    payer_id INT PRIMARY KEY,
     payer_name VARCHAR(20),
     payer_code CHAR(2)
 );
@@ -286,7 +286,7 @@ ALTER TABLE claims
         REFERENCES facility_financial_classes(financial_class_id);
 
 CREATE TABLE claims_diagnosis (
-    patient_account_number VARCHAR(50) NOT NULL,
+    claim_id VARCHAR(50) NOT NULL,
     diagnosis_sequence INT NOT NULL,
     diagnosis_code VARCHAR(20) NOT NULL,
     diagnosis_description VARCHAR(255) NULL,
@@ -296,11 +296,11 @@ CREATE TABLE claims_diagnosis (
 GO
 
 ALTER TABLE claims_diagnosis
-    ADD CONSTRAINT fk_claim_diag_claim FOREIGN KEY (patient_account_number)
-        REFERENCES claims(patient_account_number);
+    ADD CONSTRAINT fk_claim_diag_claim FOREIGN KEY (claim_id)
+        REFERENCES claims(claim_id);
 
 CREATE TABLE claims_line_items (
-    patient_account_number VARCHAR(50) NOT NULL,
+    claim_id VARCHAR(50) NOT NULL,
     line_number INT NOT NULL,
     procedure_code VARCHAR(10) NOT NULL,
     modifier1 VARCHAR(2) NULL,
@@ -322,8 +322,8 @@ CREATE TABLE claims_line_items (
 GO
 
 ALTER TABLE claims_line_items
-    ADD CONSTRAINT fk_line_claim FOREIGN KEY (patient_account_number)
-        REFERENCES claims(patient_account_number);
+    ADD CONSTRAINT fk_line_claim FOREIGN KEY (claim_id)
+        REFERENCES claims(claim_id);
 ALTER TABLE claims_line_items
     ADD CONSTRAINT fk_line_provider FOREIGN KEY (rendering_provider_id)
         REFERENCES physicians(rendering_provider_id);
@@ -456,7 +456,7 @@ CREATE INDEX ix_active_claims
 GO
 CREATE INDEX ix_unresolved_failed_claims
     ON failed_claims (claim_id)
-    WHERE resolution_status IS NULL OR resolution_status <> 'resolved';
+    WHERE ISNULL(resolution_status, '') <> 'resolved';
 GO
 ALTER TABLE archived_failed_claims REBUILD PARTITION = ALL
     WITH (DATA_COMPRESSION = PAGE);


### PR DESCRIPTION
## Summary
- fix FK reference errors in SQL Server schema
- make GO parsing more robust in setup script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684ef95ca178832aba9dbac7e1745b3c