### PR TITLE
Fix physicians table PK

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -191,7 +191,7 @@ CREATE INDEX idx_facility_coders_facility_id
 GO
 
 CREATE TABLE physicians (
-    rendering_provider_id VARCHAR(50),
+    rendering_provider_id VARCHAR(50) NOT NULL PRIMARY KEY,
     last_name VARCHAR(50),
     first_name VARCHAR(50)
 );


### PR DESCRIPTION
## Summary
- ensure `rendering_provider_id` is non-null and primary key in SQL Server schema

## Testing
- `pytest -q` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684efd6bef34832ab9dfcef84e33576f