### PR TITLE
Fix unresolved failed claims index clause

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -456,7 +456,7 @@ CREATE INDEX ix_active_claims
 GO
 CREATE INDEX ix_unresolved_failed_claims
     ON failed_claims (claim_id)
-    WHERE ISNULL(resolution_status, '') <> 'resolved';
+    WHERE resolution_status IS NULL OR resolution_status <> 'resolved'
 GO
 ALTER TABLE archived_failed_claims REBUILD PARTITION = ALL
     WITH (DATA_COMPRESSION = PAGE);


### PR DESCRIPTION
## Summary
- adjust the `ix_unresolved_failed_claims` index condition

## Testing
- `pytest -q` *(fails: 16 errors during collection)*
- `bandit -r src -ll` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efdea7c58832abcf15f5de03917fe