### PR TITLE
Fix filtered index creation for older SQL Server

### DIFF
--- a/sql/create_sqlserver_schema.sql
+++ b/sql/create_sqlserver_schema.sql
@@ -481,7 +481,9 @@ CREATE INDEX ix_active_claims
 GO
 CREATE INDEX ix_unresolved_failed_claims
     ON failed_claims (claim_id)
-    WHERE (resolution_status IS NULL OR resolution_status <> 'resolved');
+    -- SQL Server 2008 filtered indexes do not allow OR conditions.
+    -- Use ISNULL to treat NULL values as unresolved while avoiding OR.
+    WHERE ISNULL(resolution_status, '') <> 'resolved';
 GO
 ALTER TABLE archived_failed_claims REBUILD PARTITION = ALL
     WITH (DATA_COMPRESSION = PAGE);


### PR DESCRIPTION
## Summary
- fix the unresolved_failed_claims index definition for SQL Server 2008 filtered index limitations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyodbc')*

------
https://chatgpt.com/codex/tasks/task_e_684f00ada9c0832a9f1335be2e13212f