### PR TITLE
Fix SQL Server schema creation autocommit

### DIFF
--- a/src/db/sql_server.py
+++ b/src/db/sql_server.py
@@ -199,7 +199,11 @@ class SQLServerDatabase(BaseDatabase):
             f"LoginTimeout=15;"
         )
 
-        conn = pyodbc.connect(connection_string, autocommit=False)
+        # Use autocommit so that DDL statements such as CREATE PARTITION FUNCTION
+        # or ALTER TABLE are executed outside of an explicit transaction.  SQL
+        # Server does not allow some DDL inside user transactions and the setup
+        # script relies on executing them individually.
+        conn = pyodbc.connect(connection_string, autocommit=True)
         self._connection_create_count += 1
 
         # Apply connection-level optimizations

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -2,6 +2,7 @@ import json
 import logging
 import logging.handlers
 import time
+from pathlib import Path
 from typing import Dict, Optional
 
 try:  # pragma: no cover - optional dependency

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 if "numpy" not in sys.modules:
     sys.modules["numpy"] = types.ModuleType("numpy")
 
+# Stub pyodbc so tests can import database modules without the actual driver
+if "pyodbc" not in sys.modules:
+    pyodbc_mod = types.SimpleNamespace(connect=lambda *a, **k: None, Connection=object)
+    sys.modules["pyodbc"] = pyodbc_mod
+
 if "yaml" not in sys.modules:
     yaml_mod = types.ModuleType("yaml")
     yaml_mod.safe_load = lambda *a, **k: {}


### PR DESCRIPTION
## Summary
- use autocommit for SQL Server setup connections
- import `Path` in logging utils
- stub `pyodbc` for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f04097be8832a80ee22138eae0351